### PR TITLE
feat: Add model cache TTL and fix native library path resolution

### DIFF
--- a/electron/core/app-controller.ts
+++ b/electron/core/app-controller.ts
@@ -610,7 +610,11 @@ export class AppController {
   private scheduleTranscriberUnload(): void {
     this.cancelTranscriberUnload()
 
-    const ttlMinutes = this.settings.cacheTTLMinutes
+    // 验证从配置加载的 TTL 值，防止损坏的 settings.json 导致 NaN
+    const validValues = [0, 5, 15, 30, 60]
+    const rawTTL = this.settings.cacheTTLMinutes
+    const ttlMinutes = Number.isFinite(rawTTL) && validValues.includes(rawTTL) ? rawTTL : 30
+
     if (ttlMinutes <= 0) {
       // 0 或负数表示永不卸载
       logger.debug('模型缓存设置为永不卸载')

--- a/electron/core/app-controller.ts
+++ b/electron/core/app-controller.ts
@@ -45,7 +45,7 @@ export class AppController {
   private readonly conversationsDir = path.join(this.supportDir, 'conversations')
   private readonly testAudioCachePath = path.join(this.supportDir, 'cache', 'test-audio.wav')
   private readonly audioRecorder = new AudioRecorder(this.conversationsDir, this.recorderConfig)
-  private readonly transcriber: Transcriber = createTranscriber(this.transcriberConfig, { supportDir: this.supportDir })
+  private transcriber: Transcriber | null = null  // 懒加载，支持动态卸载
   private readonly conversationStore = new ConversationStore(this.conversationsDir)
   private readonly appleScriptInserter = new AppleScriptTextInserter()
 
@@ -53,6 +53,7 @@ export class AppController {
   private initialized = false
   private activeRecording: { sessionId: string; handle: RecordingHandle | NativeRecordingHandle; timeout?: NodeJS.Timeout; recordingTimer?: string } | null = null
   private idleTimer: NodeJS.Timeout | null = null
+  private cacheTimer: NodeJS.Timeout | null = null  // 模型缓存卸载计时器
   private testInProgress = false
   private settings = loadAppSettings()
 
@@ -186,9 +187,28 @@ export class AppController {
       getSettings: () => loadAppSettings(),
       updateSettings: async (settings) => {
         try {
+          // 校验 cacheTTLMinutes 入参
+          if (settings.cacheTTLMinutes !== undefined) {
+            const validValues = [0, 5, 15, 30, 60]
+            if (!Number.isFinite(settings.cacheTTLMinutes) || !validValues.includes(settings.cacheTTLMinutes)) {
+              logger.warn(`无效的缓存时间值: ${settings.cacheTTLMinutes}，回退到默认值 30`)
+              settings.cacheTTLMinutes = 30
+            }
+          }
+
           saveAppSettings(settings)
+          const oldTTL = this.settings.cacheTTLMinutes
           Object.assign(this.settings, settings)
           logger.debug('设置已更新', { settings })
+
+          // 如果缓存时间变更，重新调度卸载计时器
+          if (settings.cacheTTLMinutes !== undefined && settings.cacheTTLMinutes !== oldTTL) {
+            logger.info(`缓存时间变更：${oldTTL} -> ${settings.cacheTTLMinutes} 分钟`)
+            if (this.transcriber) {
+              this.scheduleTranscriberUnload()
+            }
+          }
+
           return { success: true }
         } catch (error) {
           logger.error(error instanceof Error ? error : new Error(String(error)), { context: 'updateSettings' })
@@ -320,7 +340,8 @@ export class AppController {
     
     try {
       recordingResult = await handle.stop()
-      const transcription = await this.transcriber.transcribe(recordingResult.audioPath)
+      const transcriber = this.ensureTranscriber()
+      const transcription = await transcriber.transcribe(recordingResult.audioPath)
       metrics.endTimer(transcriptionTimer, 'transcription', {
         sessionId,
         durationMs: transcription.durationMs,
@@ -361,6 +382,9 @@ export class AppController {
         })
       }
       this.handleError('转写失败', error, sessionId)
+    } finally {
+      // 无论成功失败都刷新缓存计时器
+      this.scheduleTranscriberUnload()
     }
   }
 
@@ -442,7 +466,8 @@ export class AppController {
         await this.downloadTestAudio(this.testAudioCachePath)
       }
 
-      const transcription = await this.transcriber.transcribe(this.testAudioCachePath)
+      const transcriber = this.ensureTranscriber()
+      const transcription = await transcriber.transcribe(this.testAudioCachePath)
       const processingTime = Date.now() - startTime
 
       const record: ConversationRecord = {
@@ -466,7 +491,6 @@ export class AppController {
       })
       this.scheduleIdle()
 
-      this.testInProgress = false
       return {
         success: true,
         data: {
@@ -481,8 +505,11 @@ export class AppController {
       const detail = error instanceof Error ? error.message : String(error)
       this.stateMachine.setError(`测试转写失败：${detail}`)
       this.scheduleIdle(4000)
-      this.testInProgress = false
       return { success: false, error: detail }
+    } finally {
+      this.testInProgress = false
+      // 无论成功失败都刷新缓存计时器
+      this.scheduleTranscriberUnload()
     }
   }
 
@@ -561,6 +588,66 @@ export class AppController {
   }
 
   /**
+   * 确保转写器可用（懒加载）
+   * 如果已销毁或未初始化，则重新创建
+   * 同时取消任何待执行的卸载计时器，防止转写过程中被卸载
+   */
+  private ensureTranscriber(): Transcriber {
+    // 关键：取消待执行的卸载计时器，防止转写过程中被卸载
+    this.cancelTranscriberUnload()
+
+    if (!this.transcriber) {
+      logger.info('创建转写器实例...')
+      this.transcriber = createTranscriber(this.transcriberConfig, { supportDir: this.supportDir })
+    }
+    return this.transcriber
+  }
+
+  /**
+   * 调度转写器卸载
+   * 根据 cacheTTLMinutes 设置延迟销毁计时器
+   */
+  private scheduleTranscriberUnload(): void {
+    this.cancelTranscriberUnload()
+
+    const ttlMinutes = this.settings.cacheTTLMinutes
+    if (ttlMinutes <= 0) {
+      // 0 或负数表示永不卸载
+      logger.debug('模型缓存设置为永不卸载')
+      return
+    }
+
+    const ttlMs = ttlMinutes * 60 * 1000
+    logger.info(`模型将在 ${ttlMinutes} 分钟后卸载`)
+
+    this.cacheTimer = setTimeout(() => {
+      this.unloadTranscriber()
+    }, ttlMs)
+  }
+
+  /**
+   * 取消转写器卸载计时器
+   */
+  private cancelTranscriberUnload(): void {
+    if (this.cacheTimer) {
+      clearTimeout(this.cacheTimer)
+      this.cacheTimer = null
+    }
+  }
+
+  /**
+   * 卸载转写器（终止 Worker 进程）
+   */
+  private unloadTranscriber(): void {
+    if (!this.transcriber) return
+
+    logger.info('卸载模型缓存，终止 Worker 进程')
+    this.transcriber.destroy?.()
+    this.transcriber = null
+    this.cacheTimer = null
+  }
+
+  /**
    * 尝试启动键盘钩子
    * 检查辅助功能权限后再启动，避免权限不足时进程退出
    */
@@ -620,6 +707,7 @@ export class AppController {
    */
   destroy(): void {
     this.cancelIdleTimer()
+    this.cancelTranscriberUnload()  // 清理缓存计时器
     if (this.activeRecording) {
       this.activeRecording.handle.forceStop()
       this.activeRecording = null
@@ -629,7 +717,8 @@ export class AppController {
     this.windowService?.destroy()
     this.ipcListeners.unregister()
     // 终止 transcriber worker 进程
-    this.transcriber.destroy?.()
+    this.transcriber?.destroy?.()
+    this.transcriber = null
     this.initialized = false
   }
 }

--- a/electron/transcriber/sensevoice-worker.cjs
+++ b/electron/transcriber/sensevoice-worker.cjs
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
-// 确保DYLD_LIBRARY_PATH设置正确
+// DYLD_LIBRARY_PATH 应由主进程通过 fork() 的 env 参数传递
+// Worker 不应覆盖主进程设置的路径，因为：
+// 1. 主进程使用 resolveRuntimeDirectory() 智能查找正确路径
+// 2. 在 worktree 环境下，node_modules 可能不在当前项目目录
+// 3. 在生产环境下，原生库在 Resources/native/ 目录
 const path = require('path');
 const fs = require('fs');
-const expectedPath = path.join(__dirname, '../../..', 'node_modules/sherpa-onnx-darwin-arm64');
-if (!process.env.DYLD_LIBRARY_PATH || !process.env.DYLD_LIBRARY_PATH.includes(expectedPath)) {
-  process.env.DYLD_LIBRARY_PATH = expectedPath + ':' + (process.env.DYLD_LIBRARY_PATH || '');
-}
 
 const sherpa = require('sherpa-onnx-node')
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,6 +61,7 @@ function App() {
   const [testCopySuccess, setTestCopySuccess] = useState(false)
   const [clipboardMode, setClipboardMode] = useState(false)
   const [autoShowOnStart, setAutoShowOnStart] = useState(false)
+  const [cacheTTLMinutes, setCacheTTLMinutes] = useState(30)
   const [appleScriptPermission, setAppleScriptPermission] = useState<{
     available: boolean
     hasPermission: boolean
@@ -93,6 +94,8 @@ function App() {
       setShortcut(s.shortcut)
       setClipboardMode(s.clipboardMode)
       setAutoShowOnStart(s.autoShowOnStart)
+      // 兜底处理：防止配置缺字段或损坏
+      setCacheTTLMinutes(Number.isFinite(s.cacheTTLMinutes) ? s.cacheTTLMinutes : 30)
     })
 
     // 检查 AppleScript 权限
@@ -218,6 +221,15 @@ function App() {
     }
   }
 
+  const updateCacheTTL = async (value: number) => {
+    setCacheTTLMinutes(value)
+    try {
+      await window.speech.updateSettings({ cacheTTLMinutes: value })
+    } catch (err) {
+      console.error('更新缓存时间设置失败:', err)
+    }
+  }
+
   const runTest = async () => {
     if (testRunning) return
     setTestRunning(true)
@@ -329,9 +341,11 @@ function App() {
           <AppSettings
             clipboardMode={clipboardMode}
             autoShowOnStart={autoShowOnStart}
+            cacheTTLMinutes={cacheTTLMinutes}
             appleScriptPermission={appleScriptPermission}
             onUpdateClipboardMode={updateClipboardMode}
             onUpdateAutoShowOnStart={updateAutoShowOnStart}
+            onUpdateCacheTTL={updateCacheTTL}
             onRefreshAppleScriptPermission={refreshAppleScriptPermission}
           />
 

--- a/src/components/AppSettings.tsx
+++ b/src/components/AppSettings.tsx
@@ -12,12 +12,26 @@ interface AppleScriptPermission {
   guide?: string
 }
 
+/**
+ * 模型缓存时间选项（分钟）
+ * 0 表示永不卸载
+ */
+const CACHE_TTL_OPTIONS = [
+  { value: 5, label: '5 分钟' },
+  { value: 15, label: '15 分钟' },
+  { value: 30, label: '30 分钟' },
+  { value: 60, label: '1 小时' },
+  { value: 0, label: '永不' },
+] as const
+
 interface AppSettingsProps {
   clipboardMode: boolean
   autoShowOnStart: boolean
+  cacheTTLMinutes: number
   appleScriptPermission: AppleScriptPermission | null
   onUpdateClipboardMode: (value: boolean) => Promise<void>
   onUpdateAutoShowOnStart: (value: boolean) => Promise<void>
+  onUpdateCacheTTL: (value: number) => Promise<void>
   onRefreshAppleScriptPermission: () => Promise<void>
 }
 
@@ -27,9 +41,11 @@ interface AppSettingsProps {
 export const AppSettings = memo<AppSettingsProps>(({
   clipboardMode,
   autoShowOnStart,
+  cacheTTLMinutes,
   appleScriptPermission,
   onUpdateClipboardMode,
   onUpdateAutoShowOnStart,
+  onUpdateCacheTTL,
   onRefreshAppleScriptPermission,
 }) => {
   const handleToggleClipboard = useCallback(() => {
@@ -39,6 +55,10 @@ export const AppSettings = memo<AppSettingsProps>(({
   const handleToggleAutoShow = useCallback(() => {
     onUpdateAutoShowOnStart(!autoShowOnStart)
   }, [autoShowOnStart, onUpdateAutoShowOnStart])
+
+  const handleCacheTTLChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+    onUpdateCacheTTL(Number(e.target.value))
+  }, [onUpdateCacheTTL])
 
   const Toggle = ({ enabled, onToggle, label }: { enabled: boolean; onToggle: () => void; label: string }) => (
     <div className="flex items-center justify-between py-1.5">
@@ -55,10 +75,24 @@ export const AppSettings = memo<AppSettingsProps>(({
   return (
     <div className="bg-white rounded-xl border border-gray-100 shadow-sm p-3">
       <span className="text-xs font-medium text-gray-600">设置</span>
-      
+
       <div className="mt-2 divide-y divide-gray-50">
         <Toggle enabled={clipboardMode} onToggle={handleToggleClipboard} label="禁用自动插入" />
         <Toggle enabled={autoShowOnStart} onToggle={handleToggleAutoShow} label="启动时显示面板" />
+        <div className="flex items-center justify-between py-1.5">
+          <span className="text-xs text-gray-600">模型缓存时间</span>
+          <select
+            value={cacheTTLMinutes}
+            onChange={handleCacheTTLChange}
+            className="text-xs bg-gray-50 border border-gray-200 rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-blue-400"
+          >
+            {CACHE_TTL_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
       </div>
 
       {appleScriptPermission && (


### PR DESCRIPTION
## Summary

- Implement lazy-loading transcriber with configurable model cache time (5m/15m/30m/1h/never)
- Add cache TTL selector UI to AppSettings component
- Fix sherpa-onnx-node path resolution to support git worktree environments by implementing upward traversal
- Replace Worker's self-calculated paths with smart main process resolution
- Add input validation for cache TTL values with fallback to default (30m)

## Key Changes

- **app-controller.ts**: Lazy-load transcriber, schedule unload timer, validate TTL settings
- **sensevoice-transcriber.ts**: Implement upward directory traversal to find node_modules (supports worktree)
- **sensevoice-worker.cjs**: Remove self-calculated paths, trust main process environment setup
- **AppSettings.tsx**: Add cache time dropdown selector
- **App.tsx**: Bind cache TTL state and callbacks

## Test Plan

- [x] Verify transcription works with different cache TTL settings
- [x] Check model unloads after TTL expires
- [x] Confirm model auto-reloads on next transcription
- [x] Test in both main project and worktree environments
- [x] Validate cache TTL input from UI
- [x] Ensure build/production environment unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)