### PR TITLE
feat: 实现基于 blockmap 的自动更新功能

### DIFF
--- a/.github/workflows/release-mac-arm64.yml
+++ b/.github/workflows/release-mac-arm64.yml
@@ -39,6 +39,8 @@ jobs:
           name: SpeechTide-mac-arm64-dmg
           path: |
             release/**/SpeechTide-*-mac-arm64.dmg
+            release/**/SpeechTide-*-mac-arm64.dmg.blockmap
+            release/**/latest-mac.yml
 
       - name: Create GitHub Release
         if: startsWith(github.ref, 'refs/tags/v')
@@ -46,5 +48,7 @@ jobs:
         with:
           files: |
             release/**/SpeechTide-*-mac-arm64.dmg
+            release/**/SpeechTide-*-mac-arm64.dmg.blockmap
+            release/**/latest-mac.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-mac-arm64.yml
+++ b/.github/workflows/release-mac-arm64.yml
@@ -40,6 +40,8 @@ jobs:
           path: |
             release/**/SpeechTide-*-mac-arm64.dmg
             release/**/SpeechTide-*-mac-arm64.dmg.blockmap
+            release/**/SpeechTide-*-mac-arm64.zip
+            release/**/SpeechTide-*-mac-arm64.zip.blockmap
             release/**/latest-mac.yml
 
       - name: Create GitHub Release
@@ -49,6 +51,8 @@ jobs:
           files: |
             release/**/SpeechTide-*-mac-arm64.dmg
             release/**/SpeechTide-*-mac-arm64.dmg.blockmap
+            release/**/SpeechTide-*-mac-arm64.zip
+            release/**/SpeechTide-*-mac-arm64.zip.blockmap
             release/**/latest-mac.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -45,7 +45,8 @@
   
   "mac": {
     "target": [
-      { "target": "dmg", "arch": ["arm64"] }
+      { "target": "dmg", "arch": ["arm64"] },
+      { "target": "zip", "arch": ["arm64"] }
     ],
     "category": "public.app-category.productivity",
     "icon": "build/icon.icns",

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -92,6 +92,46 @@ const nativeRecorderAPI = {
   },
 }
 
+// Update API - 自动更新
+const updateAPI = {
+  /** 获取更新状态 */
+  getState() {
+    return ipcRenderer.invoke('update:getState')
+  },
+  /** 检查更新 */
+  check() {
+    return ipcRenderer.invoke('update:check')
+  },
+  /** 下载更新 */
+  download() {
+    return ipcRenderer.invoke('update:download')
+  },
+  /** 立即安装（重启应用） */
+  install() {
+    return ipcRenderer.invoke('update:install')
+  },
+  /** 打开 GitHub Releases 页面 */
+  openReleasePage() {
+    return ipcRenderer.invoke('update:openReleasePage')
+  },
+  /** 获取当前版本 */
+  getVersion() {
+    return ipcRenderer.invoke('update:getVersion')
+  },
+  /** 监听状态变化 */
+  onStateChange(callback: (state: unknown) => void) {
+    const listener = (_event: IpcRendererEvent, state: unknown) => callback(state)
+    ipcRenderer.on('update:state', listener)
+    return () => ipcRenderer.off('update:state', listener)
+  },
+  /** 监听下载进度 */
+  onProgress(callback: (progress: unknown) => void) {
+    const listener = (_event: IpcRendererEvent, progress: unknown) => callback(progress)
+    ipcRenderer.on('update:progress', listener)
+    return () => ipcRenderer.off('update:progress', listener)
+  },
+}
+
 const onboardingAPI = {
   /** 获取 Onboarding 状态 */
   getState() {
@@ -161,6 +201,7 @@ try {
   contextBridge.exposeInMainWorld('speech', speechAPI)
   contextBridge.exposeInMainWorld('onboarding', onboardingAPI)
   contextBridge.exposeInMainWorld('nativeRecorder', nativeRecorderAPI)
+  contextBridge.exposeInMainWorld('update', updateAPI)
   console.log('[Preload] ✓ API 暴露成功')
 } catch (error) {
   console.error('[Preload] ❌ API 暴露失败:', error)

--- a/electron/services/update-service.ts
+++ b/electron/services/update-service.ts
@@ -1,0 +1,320 @@
+/**
+ * 自动更新服务
+ *
+ * 负责检查、下载和安装应用更新
+ * 使用 electron-updater 实现增量更新（blockmap）
+ */
+
+import { BrowserWindow, ipcMain, app, shell } from 'electron'
+import electronUpdater, { type AppUpdater, type UpdateInfo } from 'electron-updater'
+import { createModuleLogger } from '../utils/logger'
+
+const logger = createModuleLogger('update-service')
+
+/** 更新状态 */
+export type UpdateStatus =
+  | 'idle'           // 空闲
+  | 'checking'       // 检查中
+  | 'available'      // 有可用更新
+  | 'not-available'  // 已是最新
+  | 'downloading'    // 下载中
+  | 'downloaded'     // 下载完成
+  | 'error'          // 错误
+
+/** 更新进度 */
+export interface UpdateProgress {
+  percent: number
+  bytesPerSecond: number
+  total: number
+  transferred: number
+}
+
+/** 更新状态信息 */
+export interface UpdateState {
+  status: UpdateStatus
+  currentVersion: string
+  availableVersion?: string
+  releaseNotes?: string
+  progress?: UpdateProgress
+  error?: string
+}
+
+/** 状态变更回调 */
+export type UpdateStateCallback = (state: UpdateState) => void
+
+/**
+ * ESM 兼容的 autoUpdater 获取方式
+ * electron-updater 是 CommonJS 模块，需要特殊处理
+ */
+function getAutoUpdater(): AppUpdater {
+  const { autoUpdater } = electronUpdater
+  return autoUpdater
+}
+
+const GITHUB_RELEASES_URL = 'https://github.com/ChanlerDev/speechtide/releases'
+
+/**
+ * 更新服务类
+ */
+export class UpdateService {
+  private window: BrowserWindow | null = null
+  private autoUpdater: AppUpdater
+  private state: UpdateState
+  private checkInterval: NodeJS.Timeout | null = null
+  private stateCallback: UpdateStateCallback | null = null
+
+  constructor() {
+    this.autoUpdater = getAutoUpdater()
+    this.state = {
+      status: 'idle',
+      currentVersion: app.getVersion(),
+    }
+    this.configureAutoUpdater()
+  }
+
+  /**
+   * 初始化服务
+   */
+  initialize(window: BrowserWindow): void {
+    this.window = window
+    this.registerIPCHandlers()
+    logger.info('更新服务已初始化', { version: this.state.currentVersion })
+  }
+
+  /**
+   * 设置状态变更回调（用于托盘等外部组件）
+   */
+  setStateCallback(callback: UpdateStateCallback): void {
+    this.stateCallback = callback
+  }
+
+  /**
+   * 获取当前状态
+   */
+  getState(): UpdateState {
+    return { ...this.state }
+  }
+
+  /**
+   * 配置 autoUpdater
+   */
+  private configureAutoUpdater(): void {
+    // 不自动下载，让用户决定
+    this.autoUpdater.autoDownload = false
+    // 不自动安装
+    this.autoUpdater.autoInstallOnAppQuit = false
+    // 不允许降级
+    this.autoUpdater.allowDowngrade = false
+
+    // 注册事件监听
+    this.autoUpdater.on('checking-for-update', () => {
+      this.updateState({ status: 'checking' })
+      logger.info('正在检查更新...')
+    })
+
+    this.autoUpdater.on('update-available', (info: UpdateInfo) => {
+      this.updateState({
+        status: 'available',
+        availableVersion: info.version,
+        releaseNotes: typeof info.releaseNotes === 'string'
+          ? info.releaseNotes
+          : undefined,
+      })
+      logger.info('发现新版本', { version: info.version })
+    })
+
+    this.autoUpdater.on('update-not-available', (info: UpdateInfo) => {
+      this.updateState({ status: 'not-available' })
+      logger.info('当前已是最新版本', { version: info.version })
+    })
+
+    this.autoUpdater.on('download-progress', (progress) => {
+      this.updateState({
+        status: 'downloading',
+        progress: {
+          percent: progress.percent,
+          bytesPerSecond: progress.bytesPerSecond,
+          total: progress.total,
+          transferred: progress.transferred,
+        },
+      })
+      this.sendToRenderer('update:progress', progress)
+    })
+
+    this.autoUpdater.on('update-downloaded', (info: UpdateInfo) => {
+      this.updateState({
+        status: 'downloaded',
+        availableVersion: info.version,
+        progress: undefined,
+      })
+      logger.info('更新已下载完成', { version: info.version })
+    })
+
+    this.autoUpdater.on('error', (error) => {
+      this.updateState({
+        status: 'error',
+        error: error.message,
+      })
+      logger.error(error, { context: 'autoUpdater' })
+    })
+  }
+
+  /**
+   * 注册 IPC 处理器
+   */
+  private registerIPCHandlers(): void {
+    // 获取更新状态
+    ipcMain.handle('update:getState', () => {
+      return this.state
+    })
+
+    // 检查更新
+    ipcMain.handle('update:check', async () => {
+      return this.checkForUpdates()
+    })
+
+    // 下载更新
+    ipcMain.handle('update:download', async () => {
+      return this.downloadUpdate()
+    })
+
+    // 立即安装（重启应用）
+    ipcMain.handle('update:install', () => {
+      this.quitAndInstall()
+    })
+
+    // 打开 GitHub Releases 页面
+    ipcMain.handle('update:openReleasePage', () => {
+      shell.openExternal(GITHUB_RELEASES_URL)
+    })
+
+    // 获取当前版本
+    ipcMain.handle('update:getVersion', () => {
+      return app.getVersion()
+    })
+  }
+
+  /**
+   * 检查更新
+   */
+  async checkForUpdates(): Promise<{ hasUpdate: boolean; version?: string; error?: string }> {
+    try {
+      const result = await this.autoUpdater.checkForUpdates()
+      if (result?.updateInfo) {
+        const hasUpdate = result.updateInfo.version !== app.getVersion()
+        return {
+          hasUpdate,
+          version: result.updateInfo.version,
+        }
+      }
+      return { hasUpdate: false }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      logger.error(error instanceof Error ? error : new Error(message), { context: 'checkForUpdates' })
+      return { hasUpdate: false, error: message }
+    }
+  }
+
+  /**
+   * 下载更新
+   */
+  async downloadUpdate(): Promise<{ success: boolean; error?: string }> {
+    try {
+      await this.autoUpdater.downloadUpdate()
+      return { success: true }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      logger.error(error instanceof Error ? error : new Error(message), { context: 'downloadUpdate' })
+      return { success: false, error: message }
+    }
+  }
+
+  /**
+   * 退出并安装
+   */
+  quitAndInstall(): void {
+    logger.info('准备退出并安装更新...')
+    // 移除所有窗口关闭监听，允许真正退出
+    app.removeAllListeners('window-all-closed')
+    const windows = BrowserWindow.getAllWindows()
+    windows.forEach((win) => {
+      win.removeAllListeners('close')
+    })
+    this.autoUpdater.quitAndInstall()
+  }
+
+  /**
+   * 启动定时检查
+   * @param intervalMs 检查间隔（毫秒），默认 1 小时
+   */
+  startScheduledCheck(intervalMs: number = 60 * 60 * 1000): void {
+    this.stopScheduledCheck()
+
+    // 启动时延迟检查，避免启动时网络阻塞
+    setTimeout(() => {
+      this.checkForUpdates().catch((e) => logger.error(e))
+    }, 5000)
+
+    // 定时检查
+    this.checkInterval = setInterval(() => {
+      this.checkForUpdates().catch((e) => logger.error(e))
+    }, intervalMs)
+
+    logger.info(`定时检查已启动，间隔: ${intervalMs / 1000 / 60} 分钟`)
+  }
+
+  /**
+   * 停止定时检查
+   */
+  stopScheduledCheck(): void {
+    if (this.checkInterval) {
+      clearInterval(this.checkInterval)
+      this.checkInterval = null
+    }
+  }
+
+  /**
+   * 更新状态
+   */
+  private updateState(partial: Partial<UpdateState>): void {
+    this.state = { ...this.state, ...partial }
+    this.sendToRenderer('update:state', this.state)
+    // 通知外部回调（托盘等）
+    this.stateCallback?.(this.state)
+  }
+
+  /**
+   * 发送消息到渲染进程
+   */
+  private sendToRenderer(channel: string, data: unknown): void {
+    if (this.window && !this.window.isDestroyed()) {
+      this.window.webContents.send(channel, data)
+    }
+  }
+
+  /**
+   * 销毁服务
+   */
+  destroy(): void {
+    this.stopScheduledCheck()
+
+    const handlers = [
+      'update:getState',
+      'update:check',
+      'update:download',
+      'update:install',
+      'update:openReleasePage',
+      'update:getVersion',
+    ]
+    for (const handler of handlers) {
+      ipcMain.removeHandler(handler)
+    }
+
+    this.window = null
+    this.stateCallback = null
+    logger.info('更新服务已销毁')
+  }
+}
+
+// 导出单例
+export const updateService = new UpdateService()

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "electron-updater": "^6.6.2",
         "node-wav": "^0.0.2",
         "onnx-proto": "^8.0.1",
         "pino": "^10.1.0",
@@ -2732,7 +2733,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-union": {
@@ -3615,7 +3615,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4143,6 +4142,70 @@
       "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/electron-updater": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.6.2.tgz",
+      "integrity": "sha512-Cr4GDOkbAUqRHP5/oeOmH/L2Bn6+FQPxVLZtPbcmKZC63a1F3uu5EefYOssgZXG3u/zBlubbJ5PJdITdMVggbw==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.3.1",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "^7.6.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/builder-util-runtime": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.3.1.tgz",
+      "integrity": "sha512-2/egrNDDnRaxVwK3A+cJq6UOlqOdedGA7JPqCeJjN2Zjk1/QB/6QUi3b714ScIGS7HafFXTyzJEOr5b44I3kvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-updater/node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-updater/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/electron/node_modules/@types/node": {
       "version": "20.19.26",
@@ -5097,7 +5160,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/graphemer": {
@@ -5555,7 +5617,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -5643,7 +5704,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lazystream": {
@@ -5769,6 +5829,12 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
@@ -5776,6 +5842,13 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
@@ -6018,7 +6091,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -7149,7 +7221,6 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.3.tgz",
       "integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
-      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/scheduler": {
@@ -7181,7 +7252,6 @@
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7832,6 +7902,12 @@
       "dependencies": {
         "real-require": "^0.2.0"
       }
+    },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "postinstall": "node scripts/postinstall.js"
   },
   "dependencies": {
+    "electron-updater": "^6.6.2",
     "node-wav": "^0.0.2",
     "onnx-proto": "^8.0.1",
     "pino": "^10.1.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import { ShortcutSettings } from './components/ShortcutSettings'
 import { TestTranscription } from './components/TestTranscription'
 import { AppSettings } from './components/AppSettings'
 import { ErrorDisplay } from './components/ErrorDisplay'
+import { UpdateStatus } from './components/UpdateStatus'
 import { Onboarding } from './components/Onboarding'
 import { useNativeRecorder } from './hooks/useNativeRecorder'
 
@@ -351,6 +352,9 @@ function App() {
 
           {/* 错误显示 */}
           <ErrorDisplay error={state.error} />
+
+          {/* 更新状态 */}
+          <UpdateStatus />
         </div>
       </div>
     </div>

--- a/src/components/UpdateStatus.tsx
+++ b/src/components/UpdateStatus.tsx
@@ -1,0 +1,170 @@
+/**
+ * 更新状态组件
+ *
+ * 精简的单行组件，显示版本信息和更新状态
+ */
+
+import { memo, useState, useEffect, useCallback } from 'react'
+
+/** 更新状态类型（本地定义以避免全局类型问题） */
+type UpdateStatusType = 'idle' | 'checking' | 'available' | 'not-available' | 'downloading' | 'downloaded' | 'error'
+
+interface UpdateProgress {
+  percent: number
+  bytesPerSecond: number
+  total: number
+  transferred: number
+}
+
+interface UpdateStateLocal {
+  status: UpdateStatusType
+  currentVersion: string
+  availableVersion?: string
+  releaseNotes?: string
+  progress?: UpdateProgress
+  error?: string
+}
+
+export const UpdateStatus = memo(() => {
+  const [state, setState] = useState<UpdateStateLocal | null>(null)
+  const [checking, setChecking] = useState(false)
+
+  // 初始化状态
+  useEffect(() => {
+    window.update.getState().then(setState)
+    const dispose = window.update.onStateChange(setState)
+    return dispose
+  }, [])
+
+  // 检查更新
+  const handleCheck = useCallback(async () => {
+    setChecking(true)
+    try {
+      await window.update.check()
+    } finally {
+      setChecking(false)
+    }
+  }, [])
+
+  // 下载更新
+  const handleDownload = useCallback(async () => {
+    await window.update.download()
+  }, [])
+
+  // 立即安装
+  const handleInstall = useCallback(async () => {
+    await window.update.install()
+  }, [])
+
+  // 打开 GitHub Releases
+  const handleOpenReleasePage = useCallback(async () => {
+    await window.update.openReleasePage()
+  }, [])
+
+  if (!state) return null
+
+  const { status, currentVersion, availableVersion, progress } = state
+
+  // 格式化下载速度
+  const formatSpeed = (bytesPerSecond: number) => {
+    if (bytesPerSecond >= 1024 * 1024) return `${(bytesPerSecond / 1024 / 1024).toFixed(1)} MB/s`
+    if (bytesPerSecond >= 1024) return `${(bytesPerSecond / 1024).toFixed(0)} KB/s`
+    return `${bytesPerSecond} B/s`
+  }
+
+  return (
+    <div className="flex items-center justify-between text-xs text-gray-400 px-1 py-2 border-t border-gray-100">
+      <div className="flex items-center gap-2 flex-1 min-w-0">
+        {/* 空闲/已是最新 */}
+        {(status === 'idle' || status === 'not-available') && (
+          <>
+            <span className="text-gray-500">v{currentVersion}</span>
+            <button
+              onClick={handleCheck}
+              disabled={checking}
+              className="text-blue-500 hover:text-blue-600 disabled:text-gray-400"
+            >
+              {checking ? '检查中...' : '检查更新'}
+            </button>
+          </>
+        )}
+
+        {/* 检查中 */}
+        {status === 'checking' && (
+          <>
+            <span className="text-gray-500">v{currentVersion}</span>
+            <span className="flex items-center gap-1">
+              <span className="animate-spin w-3 h-3 border border-blue-500 border-t-transparent rounded-full" />
+              检查中...
+            </span>
+          </>
+        )}
+
+        {/* 有可用更新 */}
+        {status === 'available' && (
+          <>
+            <span className="text-gray-500">v{currentVersion}</span>
+            <span className="text-gray-400">→</span>
+            <span className="text-green-600 font-medium">v{availableVersion}</span>
+            <button
+              onClick={handleDownload}
+              className="px-2 py-0.5 bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors"
+            >
+              更新
+            </button>
+          </>
+        )}
+
+        {/* 下载中 */}
+        {status === 'downloading' && progress && (
+          <div className="flex items-center gap-2 flex-1">
+            <span className="text-blue-500">下载中 {progress.percent.toFixed(0)}%</span>
+            <div className="flex-1 h-1 bg-gray-200 rounded-full overflow-hidden max-w-[80px]">
+              <div
+                className="h-full bg-blue-500 transition-all duration-300"
+                style={{ width: `${progress.percent}%` }}
+              />
+            </div>
+            <span className="text-gray-400">{formatSpeed(progress.bytesPerSecond)}</span>
+          </div>
+        )}
+
+        {/* 下载完成 */}
+        {status === 'downloaded' && (
+          <>
+            <span className="text-green-600">v{availableVersion} 已就绪</span>
+            <button
+              onClick={handleInstall}
+              className="px-2 py-0.5 bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors"
+            >
+              重启安装
+            </button>
+          </>
+        )}
+
+        {/* 错误 */}
+        {status === 'error' && (
+          <>
+            <span className="text-gray-500">v{currentVersion}</span>
+            <button
+              onClick={handleCheck}
+              className="text-blue-500 hover:text-blue-600"
+            >
+              重试
+            </button>
+          </>
+        )}
+      </div>
+
+      {/* 去官网下载链接 */}
+      <button
+        onClick={handleOpenReleasePage}
+        className="text-gray-400 hover:text-blue-500 ml-2 shrink-0"
+      >
+        去官网下载
+      </button>
+    </div>
+  )
+})
+
+UpdateStatus.displayName = 'UpdateStatus'

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -38,9 +38,42 @@ interface NativeRecorderAPI {
   sendComplete: (data?: ArrayBuffer | null) => void
 }
 
+/** 更新状态 */
+type UpdateStatus = 'idle' | 'checking' | 'available' | 'not-available' | 'downloading' | 'downloaded' | 'error'
+
+/** 更新进度 */
+interface UpdateProgress {
+  percent: number
+  bytesPerSecond: number
+  total: number
+  transferred: number
+}
+
+/** 更新状态信息 */
+interface UpdateState {
+  status: UpdateStatus
+  currentVersion: string
+  availableVersion?: string
+  releaseNotes?: string
+  progress?: UpdateProgress
+  error?: string
+}
+
+interface UpdateAPI {
+  getState: () => Promise<UpdateState>
+  check: () => Promise<{ hasUpdate: boolean; version?: string; error?: string }>
+  download: () => Promise<{ success: boolean; error?: string }>
+  install: () => Promise<void>
+  openReleasePage: () => Promise<void>
+  getVersion: () => Promise<string>
+  onStateChange: (callback: (state: UpdateState) => void) => () => void
+  onProgress: (callback: (progress: UpdateProgress) => void) => () => void
+}
+
 declare global {
   interface Window {
     nativeRecorder: NativeRecorderAPI
+    update: UpdateAPI
     speech: {
       onStateChange: (callback: (state: SpeechTideState) => void) => () => void
       getState: () => Promise<SpeechTideState>


### PR DESCRIPTION
## Summary

- 新增 `UpdateService` 服务类，封装 `electron-updater` 实现增量更新
- 支持启动时检查 + 每小时定时检查 + 手动触发
- 面板底部显示版本号、更新状态和"去官网下载"链接
- 托盘菜单动态显示更新提示（有更新时）
- GitHub workflow 上传 `blockmap` 和 `latest-mac.yml` 支持自动更新

## 新增文件

| 文件 | 说明 |
|------|------|
| `electron/services/update-service.ts` | 更新服务核心类 |
| `src/components/UpdateStatus.tsx` | 面板底部更新状态组件 |

## 修改文件

- `electron/preload.ts` - 暴露 `window.update` API
- `electron/core/app-controller.ts` - 集成更新服务
- `electron/services/tray-service.ts` - 托盘菜单支持更新提示
- `src/global.d.ts` - 添加类型定义
- `src/App.tsx` - 集成 UpdateStatus 组件
- `.github/workflows/release-mac-arm64.yml` - 上传更新所需文件

## Test plan

- [ ] `npm run build` 构建成功
- [ ] 发布新版本后，旧版本应用能检测到更新
- [ ] 点击"更新"按钮能下载并提示重启
- [ ] 托盘菜单正确显示更新状态