### PR TITLE
feat: add clear history feature

### DIFF
--- a/electron/core/app-controller.ts
+++ b/electron/core/app-controller.ts
@@ -244,6 +244,25 @@ export class AppController {
       testTranscription: () => this.runTestTranscription(),
       playTestAudio: () => this.playTestAudio(),
       setShortcutRecording: (recording) => this.setShortcutRecording(recording),
+      getHistoryStats: async () => {
+        try {
+          return await this.conversationStore.getStats()
+        } catch (error) {
+          logger.error(error instanceof Error ? error : new Error(String(error)), { context: 'getHistoryStats' })
+          return { count: 0, sizeBytes: 0 }
+        }
+      },
+      clearHistory: async (options) => {
+        try {
+          const maxAgeDays = options?.maxAgeDays ?? 0
+          const result = await this.conversationStore.clearByAge(maxAgeDays)
+          logger.info('历史记录已清除', { maxAgeDays, deletedCount: result.deletedCount })
+          return { success: true, deletedCount: result.deletedCount }
+        } catch (error) {
+          logger.error(error instanceof Error ? error : new Error(String(error)), { context: 'clearHistory' })
+          return { success: false, error: String(error) }
+        }
+      },
     })
   }
 

--- a/electron/core/app-controller.ts
+++ b/electron/core/app-controller.ts
@@ -250,7 +250,7 @@ export class AppController {
           return await this.conversationStore.getStats(maxAgeDays)
         } catch (error) {
           logger.error(error instanceof Error ? error : new Error(String(error)), { context: 'getHistoryStats' })
-          return { count: 0, sizeBytes: 0 }
+          return { count: 0, sizeBytes: 0, error: '加载历史统计失败' }
         }
       },
       clearHistory: async (options) => {

--- a/electron/core/app-controller.ts
+++ b/electron/core/app-controller.ts
@@ -256,8 +256,10 @@ export class AppController {
       clearHistory: async (options) => {
         try {
           const maxAgeDays = options?.maxAgeDays ?? 0
-          const result = await this.conversationStore.clearByAge(maxAgeDays)
-          logger.info('历史记录已清除', { maxAgeDays, deletedCount: result.deletedCount })
+          // 排除当前正在进行的会话，避免删除活跃录音
+          const excludeSessionId = this.activeRecording?.sessionId
+          const result = await this.conversationStore.clearByAge(maxAgeDays, excludeSessionId)
+          logger.info('历史记录已清除', { maxAgeDays, deletedCount: result.deletedCount, excludeSessionId })
           return { success: true, deletedCount: result.deletedCount }
         } catch (error) {
           logger.error(error instanceof Error ? error : new Error(String(error)), { context: 'clearHistory' })

--- a/electron/core/app-controller.ts
+++ b/electron/core/app-controller.ts
@@ -244,9 +244,10 @@ export class AppController {
       testTranscription: () => this.runTestTranscription(),
       playTestAudio: () => this.playTestAudio(),
       setShortcutRecording: (recording) => this.setShortcutRecording(recording),
-      getHistoryStats: async () => {
+      getHistoryStats: async (options) => {
         try {
-          return await this.conversationStore.getStats()
+          const maxAgeDays = options?.maxAgeDays ?? 0
+          return await this.conversationStore.getStats(maxAgeDays)
         } catch (error) {
           logger.error(error instanceof Error ? error : new Error(String(error)), { context: 'getHistoryStats' })
           return { count: 0, sizeBytes: 0 }

--- a/electron/listeners/ipc-listeners.ts
+++ b/electron/listeners/ipc-listeners.ts
@@ -41,7 +41,7 @@ export interface IPCHandlers {
     error?: string
   }>
   playTestAudio: () => Promise<{ success: boolean; error?: string }>
-  getHistoryStats: (options: { maxAgeDays?: number }) => Promise<{ count: number; sizeBytes: number }>
+  getHistoryStats: (options: { maxAgeDays?: number }) => Promise<{ count: number; sizeBytes: number; error?: string }>
   clearHistory: (options: { maxAgeDays?: number }) => Promise<{ success: boolean; deletedCount?: number; error?: string }>
 }
 

--- a/electron/listeners/ipc-listeners.ts
+++ b/electron/listeners/ipc-listeners.ts
@@ -41,7 +41,7 @@ export interface IPCHandlers {
     error?: string
   }>
   playTestAudio: () => Promise<{ success: boolean; error?: string }>
-  getHistoryStats: () => Promise<{ count: number; sizeBytes: number }>
+  getHistoryStats: (options: { maxAgeDays?: number }) => Promise<{ count: number; sizeBytes: number }>
   clearHistory: (options: { maxAgeDays?: number }) => Promise<{ success: boolean; deletedCount?: number; error?: string }>
 }
 
@@ -121,8 +121,8 @@ export class IPCListeners {
     })
 
     // 获取历史记录统计
-    ipcMain.handle('speech:get-history-stats', async () => {
-      return this.handlers?.getHistoryStats()
+    ipcMain.handle('speech:get-history-stats', async (_event, options: { maxAgeDays?: number }) => {
+      return this.handlers?.getHistoryStats(options || {})
     })
 
     // 清除历史记录

--- a/electron/listeners/ipc-listeners.ts
+++ b/electron/listeners/ipc-listeners.ts
@@ -41,6 +41,8 @@ export interface IPCHandlers {
     error?: string
   }>
   playTestAudio: () => Promise<{ success: boolean; error?: string }>
+  getHistoryStats: () => Promise<{ count: number; sizeBytes: number }>
+  clearHistory: (options: { maxAgeDays?: number }) => Promise<{ success: boolean; deletedCount?: number; error?: string }>
 }
 
 /**
@@ -118,6 +120,16 @@ export class IPCListeners {
       this.handlers?.setShortcutRecording(recording)
     })
 
+    // 获取历史记录统计
+    ipcMain.handle('speech:get-history-stats', async () => {
+      return this.handlers?.getHistoryStats()
+    })
+
+    // 清除历史记录
+    ipcMain.handle('speech:clear-history', async (_event, options: { maxAgeDays?: number }) => {
+      return this.handlers?.clearHistory(options)
+    })
+
     this.registered = true
     console.log('[IPCListeners] ✓ IPC 处理器注册完成')
   }
@@ -139,6 +151,8 @@ export class IPCListeners {
     ipcMain.removeHandler('speech:test-transcription')
     ipcMain.removeHandler('speech:play-test-audio')
     ipcMain.removeHandler('speech:set-shortcut-recording')
+    ipcMain.removeHandler('speech:get-history-stats')
+    ipcMain.removeHandler('speech:clear-history')
 
     this.handlers = null
     this.registered = false

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -59,6 +59,14 @@ const speechAPI = {
   playTestAudio() {
     return ipcRenderer.invoke('speech:play-test-audio')
   },
+  /** 获取历史记录统计信息 */
+  getHistoryStats() {
+    return ipcRenderer.invoke('speech:get-history-stats')
+  },
+  /** 清除历史记录 */
+  clearHistory(options?: { maxAgeDays?: number }) {
+    return ipcRenderer.invoke('speech:clear-history', options || {})
+  },
   /** 监听音频播放事件 */
   onPlayAudio(callback: (audioPath: string) => void) {
     const listener = (_event: IpcRendererEvent, audioPath: string) => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -60,8 +60,8 @@ const speechAPI = {
     return ipcRenderer.invoke('speech:play-test-audio')
   },
   /** 获取历史记录统计信息 */
-  getHistoryStats() {
-    return ipcRenderer.invoke('speech:get-history-stats')
+  getHistoryStats(options?: { maxAgeDays?: number }) {
+    return ipcRenderer.invoke('speech:get-history-stats', options || {})
   },
   /** 清除历史记录 */
   clearHistory(options?: { maxAgeDays?: number }) {

--- a/electron/storage/conversation-store.ts
+++ b/electron/storage/conversation-store.ts
@@ -85,9 +85,10 @@ export class ConversationStore {
   /**
    * 按时间范围清除历史记录
    * @param maxAgeDays 清除多少天前的记录，0 表示清除全部
+   * @param excludeSessionId 要排除的会话ID（避免删除正在进行的会话）
    * @returns 删除的会话数量
    */
-  async clearByAge(maxAgeDays: number): Promise<{ deletedCount: number }> {
+  async clearByAge(maxAgeDays: number, excludeSessionId?: string): Promise<{ deletedCount: number }> {
     let deletedCount = 0
     const now = Date.now()
     const maxAgeMs = maxAgeDays * 24 * 60 * 60 * 1000
@@ -100,6 +101,9 @@ export class ConversationStore {
         // 验证目录名格式（UUID），防止误删其他文件
         const uuidPattern = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i
         if (!uuidPattern.test(entry.name)) continue
+
+        // 跳过当前正在进行的会话
+        if (excludeSessionId && entry.name === excludeSessionId) continue
 
         const sessionDir = path.join(this.baseDir, entry.name)
         let shouldDelete = false

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -117,10 +117,10 @@ function App() {
     }
     checkAppleScript()
 
-    // 加载历史记录统计
+    // 加载历史记录统计（默认7天前）
     const loadHistoryStats = async () => {
       try {
-        const stats = await window.speech.getHistoryStats()
+        const stats = await window.speech.getHistoryStats({ maxAgeDays: 7 })
         setHistoryStats(stats)
       } catch (err) {
         console.error('加载历史记录统计失败:', err)
@@ -274,9 +274,9 @@ function App() {
     }
   }
 
-  const refreshHistoryStats = async () => {
+  const refreshHistoryStats = async (maxAgeDays: number) => {
     try {
-      const stats = await window.speech.getHistoryStats()
+      const stats = await window.speech.getHistoryStats({ maxAgeDays })
       setHistoryStats(stats)
     } catch (err) {
       console.error('刷新历史记录统计失败:', err)

--- a/src/components/AppSettings.tsx
+++ b/src/components/AppSettings.tsx
@@ -3,13 +3,18 @@
  * MIT License
  */
 
-import { memo, useCallback } from 'react'
+import { memo, useCallback, useState } from 'react'
 
 interface AppleScriptPermission {
   available: boolean
   hasPermission: boolean
   message: string
   guide?: string
+}
+
+interface HistoryStats {
+  count: number
+  sizeBytes: number
 }
 
 /**
@@ -24,15 +29,42 @@ const CACHE_TTL_OPTIONS = [
   { value: 0, label: '永不' },
 ] as const
 
+/**
+ * 清除历史时间范围选项（天）
+ * 0 表示清除全部
+ */
+const CLEAR_AGE_OPTIONS = [
+  { value: 1, label: '1 天前' },
+  { value: 3, label: '3 天前' },
+  { value: 7, label: '7 天前' },
+  { value: 30, label: '30 天前' },
+  { value: 0, label: '全部' },
+] as const
+
+/**
+ * 格式化字节数为可读字符串
+ */
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B'
+  const k = 1024
+  const sizes = ['B', 'KB', 'MB', 'GB']
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  return `${(bytes / Math.pow(k, i)).toFixed(1)} ${sizes[i]}`
+}
+
 interface AppSettingsProps {
   clipboardMode: boolean
   autoShowOnStart: boolean
   cacheTTLMinutes: number
   appleScriptPermission: AppleScriptPermission | null
+  historyStats: HistoryStats | null
+  isClearing: boolean
   onUpdateClipboardMode: (value: boolean) => Promise<void>
   onUpdateAutoShowOnStart: (value: boolean) => Promise<void>
   onUpdateCacheTTL: (value: number) => Promise<void>
   onRefreshAppleScriptPermission: () => Promise<void>
+  onClearHistory: (maxAgeDays: number) => Promise<void>
+  onRefreshHistoryStats: () => Promise<void>
 }
 
 /**
@@ -43,11 +75,18 @@ export const AppSettings = memo<AppSettingsProps>(({
   autoShowOnStart,
   cacheTTLMinutes,
   appleScriptPermission,
+  historyStats,
+  isClearing,
   onUpdateClipboardMode,
   onUpdateAutoShowOnStart,
   onUpdateCacheTTL,
   onRefreshAppleScriptPermission,
+  onClearHistory,
+  onRefreshHistoryStats,
 }) => {
+  const [showConfirm, setShowConfirm] = useState(false)
+  const [selectedAge, setSelectedAge] = useState(7)
+
   const handleToggleClipboard = useCallback(() => {
     onUpdateClipboardMode(!clipboardMode)
   }, [clipboardMode, onUpdateClipboardMode])
@@ -59,6 +98,12 @@ export const AppSettings = memo<AppSettingsProps>(({
   const handleCacheTTLChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
     onUpdateCacheTTL(Number(e.target.value))
   }, [onUpdateCacheTTL])
+
+  const handleClearConfirm = useCallback(async () => {
+    setShowConfirm(false)
+    await onClearHistory(selectedAge)
+    await onRefreshHistoryStats()
+  }, [selectedAge, onClearHistory, onRefreshHistoryStats])
 
   const Toggle = ({ enabled, onToggle, label }: { enabled: boolean; onToggle: () => void; label: string }) => (
     <div className="flex items-center justify-between py-1.5">
@@ -106,6 +151,66 @@ export const AppSettings = memo<AppSettingsProps>(({
               </button>
             </div>
           </div>
+        </div>
+      )}
+
+      {historyStats && (
+        <div className="mt-3 pt-2 border-t border-gray-100">
+          <div className="flex items-center justify-between mb-2">
+            <div>
+              <span className="text-xs text-gray-500">历史记录</span>
+              <p className="text-xs text-gray-400 mt-0.5">
+                {historyStats.count} 条，共 {formatBytes(historyStats.sizeBytes)}
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <select
+              value={selectedAge}
+              onChange={(e) => setSelectedAge(Number(e.target.value))}
+              disabled={isClearing || historyStats.count === 0}
+              className="flex-1 text-xs bg-gray-50 border border-gray-200 rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-blue-400 disabled:opacity-50"
+            >
+              {CLEAR_AGE_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+            <button
+              onClick={() => setShowConfirm(true)}
+              disabled={isClearing || historyStats.count === 0}
+              className={`px-2.5 py-1 text-xs rounded transition-colors ${
+                isClearing || historyStats.count === 0
+                  ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
+                  : 'bg-red-50 text-red-600 hover:bg-red-100'
+              }`}
+            >
+              {isClearing ? '清除中...' : '清除'}
+            </button>
+          </div>
+
+          {showConfirm && (
+            <div className="mt-2 p-2 bg-amber-50 border border-amber-200 rounded-lg">
+              <p className="text-xs text-amber-700 mb-2">
+                确定要删除{selectedAge === 0 ? '全部' : ` ${selectedAge} 天前的`}历史记录吗？此操作不可恢复。
+              </p>
+              <div className="flex justify-end gap-2">
+                <button
+                  onClick={() => setShowConfirm(false)}
+                  className="px-2 py-1 text-xs bg-white border border-gray-200 rounded hover:bg-gray-50"
+                >
+                  取消
+                </button>
+                <button
+                  onClick={handleClearConfirm}
+                  className="px-2 py-1 text-xs bg-red-500 text-white rounded hover:bg-red-600"
+                >
+                  确认删除
+                </button>
+              </div>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/components/AppSettings.tsx
+++ b/src/components/AppSettings.tsx
@@ -64,7 +64,7 @@ interface AppSettingsProps {
   onUpdateCacheTTL: (value: number) => Promise<void>
   onRefreshAppleScriptPermission: () => Promise<void>
   onClearHistory: (maxAgeDays: number) => Promise<void>
-  onRefreshHistoryStats: () => Promise<void>
+  onRefreshHistoryStats: (maxAgeDays: number) => Promise<void>
 }
 
 /**
@@ -99,10 +99,16 @@ export const AppSettings = memo<AppSettingsProps>(({
     onUpdateCacheTTL(Number(e.target.value))
   }, [onUpdateCacheTTL])
 
+  const handleAgeChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newAge = Number(e.target.value)
+    setSelectedAge(newAge)
+    onRefreshHistoryStats(newAge)
+  }, [onRefreshHistoryStats])
+
   const handleClearConfirm = useCallback(async () => {
     setShowConfirm(false)
     await onClearHistory(selectedAge)
-    await onRefreshHistoryStats()
+    await onRefreshHistoryStats(selectedAge)
   }, [selectedAge, onClearHistory, onRefreshHistoryStats])
 
   const Toggle = ({ enabled, onToggle, label }: { enabled: boolean; onToggle: () => void; label: string }) => (
@@ -157,18 +163,18 @@ export const AppSettings = memo<AppSettingsProps>(({
       {historyStats && (
         <div className="mt-3 pt-2 border-t border-gray-100">
           <div className="flex items-center justify-between mb-2">
-            <div>
-              <span className="text-xs text-gray-500">历史记录</span>
-              <p className="text-xs text-gray-400 mt-0.5">
-                {historyStats.count} 条，共 {formatBytes(historyStats.sizeBytes)}
-              </p>
-            </div>
+            <span className="text-xs text-gray-500">
+              历史记录
+              <span className="text-gray-400 ml-1">
+                {historyStats.count} 条，{formatBytes(historyStats.sizeBytes)}
+              </span>
+            </span>
           </div>
           <div className="flex items-center gap-2">
             <select
               value={selectedAge}
-              onChange={(e) => setSelectedAge(Number(e.target.value))}
-              disabled={isClearing || historyStats.count === 0}
+              onChange={handleAgeChange}
+              disabled={isClearing}
               className="flex-1 text-xs bg-gray-50 border border-gray-200 rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-blue-400 disabled:opacity-50"
             >
               {CLEAR_AGE_OPTIONS.map((opt) => (

--- a/src/components/AppSettings.tsx
+++ b/src/components/AppSettings.tsx
@@ -15,6 +15,7 @@ interface AppleScriptPermission {
 interface HistoryStats {
   count: number
   sizeBytes: number
+  error?: string
 }
 
 /**
@@ -59,6 +60,7 @@ interface AppSettingsProps {
   appleScriptPermission: AppleScriptPermission | null
   historyStats: HistoryStats | null
   isClearing: boolean
+  clearError: string | null
   onUpdateClipboardMode: (value: boolean) => Promise<void>
   onUpdateAutoShowOnStart: (value: boolean) => Promise<void>
   onUpdateCacheTTL: (value: number) => Promise<void>
@@ -77,6 +79,7 @@ export const AppSettings = memo<AppSettingsProps>(({
   appleScriptPermission,
   historyStats,
   isClearing,
+  clearError,
   onUpdateClipboardMode,
   onUpdateAutoShowOnStart,
   onUpdateCacheTTL,
@@ -165,9 +168,13 @@ export const AppSettings = memo<AppSettingsProps>(({
           <div className="flex items-center justify-between mb-2">
             <span className="text-xs text-gray-500">
               历史记录
-              <span className="text-gray-400 ml-1">
-                {historyStats.count} 条，{formatBytes(historyStats.sizeBytes)}
-              </span>
+              {historyStats.error ? (
+                <span className="text-red-500 ml-1">{historyStats.error}</span>
+              ) : (
+                <span className="text-gray-400 ml-1">
+                  {historyStats.count} 条，{formatBytes(historyStats.sizeBytes)}
+                </span>
+              )}
             </span>
           </div>
           <div className="flex items-center gap-2">
@@ -185,9 +192,9 @@ export const AppSettings = memo<AppSettingsProps>(({
             </select>
             <button
               onClick={() => setShowConfirm(true)}
-              disabled={isClearing || historyStats.count === 0}
+              disabled={isClearing || historyStats.count === 0 || !!historyStats.error}
               className={`px-2.5 py-1 text-xs rounded transition-colors ${
-                isClearing || historyStats.count === 0
+                isClearing || historyStats.count === 0 || historyStats.error
                   ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
                   : 'bg-red-50 text-red-600 hover:bg-red-100'
               }`}
@@ -195,6 +202,12 @@ export const AppSettings = memo<AppSettingsProps>(({
               {isClearing ? '清除中...' : '清除'}
             </button>
           </div>
+
+          {clearError && (
+            <div className="mt-2 p-2 bg-red-50 border border-red-200 rounded-lg">
+              <p className="text-xs text-red-600">{clearError}</p>
+            </div>
+          )}
 
           {showConfirm && (
             <div className="mt-2 p-2 bg-amber-50 border border-amber-200 rounded-lg">

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -87,6 +87,8 @@ declare global {
       updateSettings: (settings: Partial<{ autoInsertText: boolean; clipboardMode: boolean; notificationEnabled: boolean; autoShowOnStart: boolean; cacheTTLMinutes: number }>) => Promise<{ success: boolean; error?: string }>
       checkAppleScriptPermission: () => Promise<{ available: boolean; hasPermission: boolean; message: string; guide?: string }>
       playTestAudio: () => Promise<{ success: boolean; error?: string }>
+      getHistoryStats: () => Promise<{ count: number; sizeBytes: number }>
+      clearHistory: (options?: { maxAgeDays?: number }) => Promise<{ success: boolean; deletedCount?: number; error?: string }>
       onPlayAudio: (callback: (audioPath: string) => void) => () => void
     }
     onboarding: {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -87,7 +87,7 @@ declare global {
       updateSettings: (settings: Partial<{ autoInsertText: boolean; clipboardMode: boolean; notificationEnabled: boolean; autoShowOnStart: boolean; cacheTTLMinutes: number }>) => Promise<{ success: boolean; error?: string }>
       checkAppleScriptPermission: () => Promise<{ available: boolean; hasPermission: boolean; message: string; guide?: string }>
       playTestAudio: () => Promise<{ success: boolean; error?: string }>
-      getHistoryStats: (options?: { maxAgeDays?: number }) => Promise<{ count: number; sizeBytes: number }>
+      getHistoryStats: (options?: { maxAgeDays?: number }) => Promise<{ count: number; sizeBytes: number; error?: string }>
       clearHistory: (options?: { maxAgeDays?: number }) => Promise<{ success: boolean; deletedCount?: number; error?: string }>
       onPlayAudio: (callback: (audioPath: string) => void) => () => void
     }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -87,7 +87,7 @@ declare global {
       updateSettings: (settings: Partial<{ autoInsertText: boolean; clipboardMode: boolean; notificationEnabled: boolean; autoShowOnStart: boolean; cacheTTLMinutes: number }>) => Promise<{ success: boolean; error?: string }>
       checkAppleScriptPermission: () => Promise<{ available: boolean; hasPermission: boolean; message: string; guide?: string }>
       playTestAudio: () => Promise<{ success: boolean; error?: string }>
-      getHistoryStats: () => Promise<{ count: number; sizeBytes: number }>
+      getHistoryStats: (options?: { maxAgeDays?: number }) => Promise<{ count: number; sizeBytes: number }>
       clearHistory: (options?: { maxAgeDays?: number }) => Promise<{ success: boolean; deletedCount?: number; error?: string }>
       onPlayAudio: (callback: (audioPath: string) => void) => () => void
     }


### PR DESCRIPTION
## Summary
- Add clear history button in settings to delete conversation recordings and wav files
- Support time range selection: 1 day / 3 days / 7 days / 30 days / all
- Display history stats (record count and storage size)
- Confirmation dialog to prevent accidental deletion

## Test plan
- [ ] Open settings panel and verify history stats are displayed
- [ ] Select different time ranges from dropdown
- [ ] Click clear button and verify confirmation dialog appears
- [ ] Confirm deletion and verify records are removed
- [ ] Verify UI updates with new stats after clearing