### PR TITLE
feat: add history panel

### DIFF
--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -67,6 +67,18 @@ const speechAPI = {
   clearHistory(options?: { maxAgeDays?: number }) {
     return ipcRenderer.invoke('speech:clear-history', options || {})
   },
+  /** 获取历史记录列表 */
+  getHistoryList(options?: { limit?: number; offset?: number }) {
+    return ipcRenderer.invoke('speech:get-history-list', options || {})
+  },
+  /** 删除单条历史记录 */
+  deleteHistoryItem(sessionId: string) {
+    return ipcRenderer.invoke('speech:delete-history-item', sessionId)
+  },
+  /** 播放历史录音 */
+  playHistoryAudio(sessionId: string) {
+    return ipcRenderer.invoke('speech:play-history-audio', sessionId)
+  },
   /** 监听音频播放事件 */
   onPlayAudio(callback: (audioPath: string) => void) {
     const listener = (_event: IpcRendererEvent, audioPath: string) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -357,12 +357,13 @@ function App() {
               {/* 历史记录按钮 */}
               <button
                 onClick={() => setShowHistory(true)}
-                className="p-1.5 rounded-md hover:bg-gray-100 text-gray-500 hover:text-gray-700 transition-colors"
+                className="flex items-center gap-1 px-2 py-1 rounded-md bg-gray-100 hover:bg-gray-200 text-gray-600 hover:text-gray-800 transition-colors"
                 title="历史记录"
               >
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
+                <span className="text-xs">历史</span>
               </button>
               <div className="flex items-center gap-1.5">
                 <div className={`w-2 h-2 rounded-full ${currentStatus.color}`} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ import { AppSettings } from './components/AppSettings'
 import { ErrorDisplay } from './components/ErrorDisplay'
 import { UpdateStatus } from './components/UpdateStatus'
 import { Onboarding } from './components/Onboarding'
+import { HistoryPanel } from './components/HistoryPanel'
 import { useNativeRecorder } from './hooks/useNativeRecorder'
 
 const INITIAL_STATE: SpeechTideState = {
@@ -52,6 +53,7 @@ interface TestResult {
  */
 function App() {
   const [showOnboarding, setShowOnboarding] = useState<boolean | null>(null)
+  const [showHistory, setShowHistory] = useState(false)
   const [state, setState] = useState<SpeechTideState>(INITIAL_STATE)
   const [shortcut, setShortcut] = useState<ShortcutConfig | null>(null)
   const [isRecordingShortcut, setIsRecordingShortcut] = useState(false)
@@ -321,6 +323,11 @@ function App() {
     return <Onboarding onComplete={() => setShowOnboarding(false)} />
   }
 
+  // 显示历史记录面板
+  if (showHistory) {
+    return <HistoryPanel onBack={() => setShowHistory(false)} />
+  }
+
   // 状态指示器颜色
   const statusConfig = {
     idle: { color: 'bg-gray-400', label: '就绪' },
@@ -346,9 +353,21 @@ function App() {
                 <p className="text-xs text-gray-400 truncate max-w-[180px]">{state.message}</p>
               </div>
             </div>
-            <div className="flex items-center gap-1.5">
-              <div className={`w-2 h-2 rounded-full ${currentStatus.color}`} />
-              <span className="text-xs text-gray-500">{currentStatus.label}</span>
+            <div className="flex items-center gap-2">
+              {/* 历史记录按钮 */}
+              <button
+                onClick={() => setShowHistory(true)}
+                className="p-1.5 rounded-md hover:bg-gray-100 text-gray-500 hover:text-gray-700 transition-colors"
+                title="历史记录"
+              >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+              </button>
+              <div className="flex items-center gap-1.5">
+                <div className={`w-2 h-2 rounded-full ${currentStatus.color}`} />
+                <span className="text-xs text-gray-500">{currentStatus.label}</span>
+              </div>
             </div>
           </div>
 

--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -4,18 +4,7 @@
  */
 
 import { memo, useState, useEffect, useCallback, useRef } from 'react'
-
-interface HistoryRecord {
-  id: string
-  startedAt: number
-  finishedAt: number
-  durationMs: number
-  audioPath: string
-  transcript?: string
-  modelId?: string
-  language?: string
-  error?: string
-}
+import type { ConversationRecord } from '../../shared/conversation'
 
 interface HistoryPanelProps {
   onBack: () => void
@@ -60,7 +49,7 @@ function formatDuration(ms: number): string {
  * 历史记录面板
  */
 export const HistoryPanel = memo<HistoryPanelProps>(({ onBack }) => {
-  const [records, setRecords] = useState<HistoryRecord[]>([])
+  const [records, setRecords] = useState<ConversationRecord[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [copiedId, setCopiedId] = useState<string | null>(null)
@@ -91,7 +80,7 @@ export const HistoryPanel = memo<HistoryPanelProps>(({ onBack }) => {
   }, [loadHistory])
 
   // 复制文本
-  const handleCopy = async (record: HistoryRecord) => {
+  const handleCopy = async (record: ConversationRecord) => {
     if (!record.transcript) return
     try {
       await navigator.clipboard.writeText(record.transcript)
@@ -107,7 +96,7 @@ export const HistoryPanel = memo<HistoryPanelProps>(({ onBack }) => {
   }
 
   // 播放音频
-  const handlePlay = async (record: HistoryRecord) => {
+  const handlePlay = async (record: ConversationRecord) => {
     if (playingId === record.id) return
     setPlayingId(record.id)
     try {
@@ -121,7 +110,7 @@ export const HistoryPanel = memo<HistoryPanelProps>(({ onBack }) => {
   }
 
   // 删除记录
-  const handleDelete = async (record: HistoryRecord) => {
+  const handleDelete = async (record: ConversationRecord) => {
     if (deletingId === record.id) return
     setDeletingId(record.id)
     try {

--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -1,0 +1,281 @@
+/**
+ * Copyright (c) 2025 SpeechTide Contributors
+ * MIT License
+ */
+
+import { memo, useState, useEffect, useCallback } from 'react'
+
+interface HistoryRecord {
+  id: string
+  startedAt: number
+  finishedAt: number
+  durationMs: number
+  audioPath: string
+  transcript?: string
+  modelId?: string
+  language?: string
+  error?: string
+}
+
+interface HistoryPanelProps {
+  onBack: () => void
+}
+
+/**
+ * 格式化时间戳为可读字符串
+ */
+function formatTime(timestamp: number): string {
+  const date = new Date(timestamp)
+  const now = new Date()
+  const isToday = date.toDateString() === now.toDateString()
+  const yesterday = new Date(now)
+  yesterday.setDate(yesterday.getDate() - 1)
+  const isYesterday = date.toDateString() === yesterday.toDateString()
+
+  const timeStr = date.toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit' })
+
+  if (isToday) {
+    return `今天 ${timeStr}`
+  } else if (isYesterday) {
+    return `昨天 ${timeStr}`
+  } else {
+    return date.toLocaleDateString('zh-CN', { month: 'short', day: 'numeric' }) + ' ' + timeStr
+  }
+}
+
+/**
+ * 格式化时长
+ */
+function formatDuration(ms: number): string {
+  const seconds = Math.round(ms / 1000)
+  if (seconds < 60) {
+    return `${seconds}s`
+  }
+  const minutes = Math.floor(seconds / 60)
+  const remainingSeconds = seconds % 60
+  return `${minutes}m${remainingSeconds}s`
+}
+
+/**
+ * 历史记录面板
+ */
+export const HistoryPanel = memo<HistoryPanelProps>(({ onBack }) => {
+  const [records, setRecords] = useState<HistoryRecord[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [copiedId, setCopiedId] = useState<string | null>(null)
+  const [playingId, setPlayingId] = useState<string | null>(null)
+  const [deletingId, setDeletingId] = useState<string | null>(null)
+
+  // 加载历史记录
+  const loadHistory = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const result = await window.speech.getHistoryList({ limit: 100 })
+      if (result.error) {
+        setError(result.error)
+      } else {
+        setRecords(result.records || [])
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '加载失败')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    loadHistory()
+  }, [loadHistory])
+
+  // 复制文本
+  const handleCopy = async (record: HistoryRecord) => {
+    if (!record.transcript) return
+    try {
+      await navigator.clipboard.writeText(record.transcript)
+      setCopiedId(record.id)
+      setTimeout(() => setCopiedId(null), 2000)
+    } catch (err) {
+      console.error('复制失败:', err)
+    }
+  }
+
+  // 播放音频
+  const handlePlay = async (record: HistoryRecord) => {
+    if (playingId === record.id) return
+    setPlayingId(record.id)
+    try {
+      await window.speech.playHistoryAudio(record.id)
+    } catch (err) {
+      console.error('播放失败:', err)
+    } finally {
+      // 延迟重置播放状态，给音频一些播放时间
+      setTimeout(() => setPlayingId(null), 1000)
+    }
+  }
+
+  // 删除记录
+  const handleDelete = async (record: HistoryRecord) => {
+    if (deletingId === record.id) return
+    setDeletingId(record.id)
+    try {
+      const result = await window.speech.deleteHistoryItem(record.id)
+      if (result.success) {
+        setRecords(prev => prev.filter(r => r.id !== record.id))
+      } else {
+        console.error('删除失败:', result.error)
+      }
+    } catch (err) {
+      console.error('删除失败:', err)
+    } finally {
+      setDeletingId(null)
+    }
+  }
+
+  return (
+    <div className="h-full bg-gradient-to-b from-slate-50 to-white flex flex-col">
+      {/* 头部 */}
+      <div className="flex items-center gap-3 px-4 py-3 border-b border-gray-100 bg-white/80 backdrop-blur-sm">
+        <button
+          onClick={onBack}
+          className="flex items-center gap-1 text-sm text-gray-600 hover:text-gray-800 transition-colors"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+          返回
+        </button>
+        <h2 className="text-sm font-semibold text-gray-800 flex-1">历史记录</h2>
+        <span className="text-xs text-gray-400">{records.length} 条</span>
+      </div>
+
+      {/* 复制成功提示 - 固定在顶部 */}
+      {copiedId && (
+        <div className="absolute top-14 left-1/2 -translate-x-1/2 bg-green-500 text-white text-xs px-3 py-1.5 rounded-full shadow-lg z-50 animate-bounce">
+          已复制到剪贴板
+        </div>
+      )}
+
+      {/* 内容区域 */}
+      <div className="flex-1 overflow-y-auto">
+        {loading ? (
+          <div className="flex items-center justify-center h-32">
+            <div className="animate-spin w-6 h-6 border-2 border-blue-500 border-t-transparent rounded-full" />
+          </div>
+        ) : error ? (
+          <div className="p-4 text-center">
+            <p className="text-red-500 text-sm">{error}</p>
+            <button
+              onClick={loadHistory}
+              className="mt-2 text-xs text-blue-600 hover:underline"
+            >
+              重试
+            </button>
+          </div>
+        ) : records.length === 0 ? (
+          <div className="p-8 text-center">
+            <div className="text-4xl mb-3">📝</div>
+            <p className="text-gray-400 text-sm">暂无历史记录</p>
+            <p className="text-gray-300 text-xs mt-1">开始录音后会自动保存</p>
+          </div>
+        ) : (
+          <div className="p-2 space-y-2">
+            {records.map((record) => (
+              <div
+                key={record.id}
+                onClick={() => handleCopy(record)}
+                className={`bg-white rounded-lg border shadow-sm p-3 cursor-pointer transition-all
+                  ${copiedId === record.id
+                    ? 'border-green-300 bg-green-50'
+                    : 'border-gray-100 hover:border-gray-200 hover:shadow'
+                  }
+                  ${record.error ? 'opacity-60' : ''}
+                `}
+              >
+                {/* 顶部：时间和操作按钮 */}
+                <div className="flex items-center justify-between mb-2">
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs text-gray-400">{formatTime(record.finishedAt)}</span>
+                    <span className="text-xs text-gray-300">|</span>
+                    <span className="text-xs text-gray-400">{formatDuration(record.durationMs)}</span>
+                    {record.language && (
+                      <>
+                        <span className="text-xs text-gray-300">|</span>
+                        <span className="text-xs text-gray-400">{record.language}</span>
+                      </>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-1" onClick={e => e.stopPropagation()}>
+                    {/* 播放按钮 */}
+                    <button
+                      onClick={() => handlePlay(record)}
+                      disabled={playingId === record.id}
+                      className={`p-1.5 rounded-md transition-colors ${
+                        playingId === record.id
+                          ? 'bg-blue-100 text-blue-600'
+                          : 'hover:bg-gray-100 text-gray-500 hover:text-gray-700'
+                      }`}
+                      title="播放录音"
+                    >
+                      {playingId === record.id ? (
+                        <svg className="w-4 h-4 animate-pulse" fill="currentColor" viewBox="0 0 24 24">
+                          <path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z" />
+                        </svg>
+                      ) : (
+                        <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+                          <path d="M8 5v14l11-7z" />
+                        </svg>
+                      )}
+                    </button>
+                    {/* 删除按钮 */}
+                    <button
+                      onClick={() => handleDelete(record)}
+                      disabled={deletingId === record.id}
+                      className={`p-1.5 rounded-md transition-colors ${
+                        deletingId === record.id
+                          ? 'bg-red-100 text-red-600'
+                          : 'hover:bg-red-50 text-gray-400 hover:text-red-500'
+                      }`}
+                      title="删除记录"
+                    >
+                      {deletingId === record.id ? (
+                        <div className="w-4 h-4 border-2 border-red-500 border-t-transparent rounded-full animate-spin" />
+                      ) : (
+                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                        </svg>
+                      )}
+                    </button>
+                  </div>
+                </div>
+
+                {/* 转录文本 */}
+                <div className="min-h-[36px]">
+                  {record.error ? (
+                    <p className="text-red-400 text-sm">转写失败: {record.error}</p>
+                  ) : record.transcript ? (
+                    <p className="text-gray-700 text-sm leading-relaxed line-clamp-3">
+                      {record.transcript}
+                    </p>
+                  ) : (
+                    <p className="text-gray-300 text-sm">无转录内容</p>
+                  )}
+                </div>
+
+                {/* 复制提示 */}
+                {copiedId === record.id && (
+                  <div className="mt-2 text-xs text-green-600 font-medium">
+                    已复制
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+})
+
+HistoryPanel.displayName = 'HistoryPanel'

--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -139,14 +139,14 @@ export const HistoryPanel = memo<HistoryPanelProps>(({ onBack }) => {
   }
 
   return (
-    <div className="h-full bg-gradient-to-b from-slate-50 to-white flex flex-col overflow-hidden">
+    <div className="fixed inset-0 bg-gradient-to-b from-slate-50 to-white flex flex-col">
       {/* 固定头部区域 */}
-      <div className="flex-shrink-0 sticky top-0 z-10">
+      <div className="flex-shrink-0">
         {/* macOS 交通灯安全区域 */}
         <div className="h-7 bg-white/80" style={{ WebkitAppRegion: 'drag' } as React.CSSProperties} />
 
         {/* 头部 */}
-        <div className="flex items-center gap-3 px-4 py-2 border-b border-gray-100 bg-white/80 backdrop-blur-sm">
+        <div className="flex items-center gap-3 px-4 py-2 border-b border-gray-100 bg-white/95">
           <button
             onClick={onBack}
             className="flex items-center gap-1 px-2 py-1 rounded-md bg-gray-100 hover:bg-gray-200 text-gray-600 hover:text-gray-800 transition-colors"

--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -95,7 +95,7 @@ export const HistoryPanel = memo<HistoryPanelProps>(({ onBack }) => {
     try {
       await navigator.clipboard.writeText(record.transcript)
       setCopiedId(record.id)
-      setTimeout(() => setCopiedId(null), 2000)
+      setTimeout(() => setCopiedId(null), 3000)
     } catch (err) {
       console.error('复制失败:', err)
     }
@@ -149,16 +149,16 @@ export const HistoryPanel = memo<HistoryPanelProps>(({ onBack }) => {
           </svg>
           <span className="text-xs">返回</span>
         </button>
-        <h2 className="text-sm font-semibold text-gray-800 flex-1">历史记录</h2>
+        <div className="flex items-center gap-2 flex-1">
+          <h2 className="text-sm font-semibold text-gray-800">历史记录</h2>
+          {copiedId && (
+            <span className="text-xs text-green-600 font-medium animate-fade-in">
+              已复制到剪贴板
+            </span>
+          )}
+        </div>
         <span className="text-xs text-gray-400">{records.length} 条</span>
       </div>
-
-      {/* 复制成功提示 - 固定在顶部 */}
-      {copiedId && (
-        <div className="absolute top-20 left-1/2 -translate-x-1/2 bg-green-500 text-white text-xs px-3 py-1.5 rounded-full shadow-lg z-50 animate-bounce">
-          已复制到剪贴板
-        </div>
-      )}
 
       {/* 内容区域 */}
       <div className="flex-1 overflow-y-auto">

--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -135,16 +135,19 @@ export const HistoryPanel = memo<HistoryPanelProps>(({ onBack }) => {
 
   return (
     <div className="h-full bg-gradient-to-b from-slate-50 to-white flex flex-col">
+      {/* macOS 交通灯安全区域 */}
+      <div className="h-7 flex-shrink-0 bg-white/80" style={{ WebkitAppRegion: 'drag' } as React.CSSProperties} />
+
       {/* 头部 */}
-      <div className="flex items-center gap-3 px-4 py-3 border-b border-gray-100 bg-white/80 backdrop-blur-sm">
+      <div className="flex items-center gap-3 px-4 py-2 border-b border-gray-100 bg-white/80 backdrop-blur-sm">
         <button
           onClick={onBack}
-          className="flex items-center gap-1 text-sm text-gray-600 hover:text-gray-800 transition-colors"
+          className="flex items-center gap-1 px-2 py-1 rounded-md bg-gray-100 hover:bg-gray-200 text-gray-600 hover:text-gray-800 transition-colors"
         >
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
           </svg>
-          返回
+          <span className="text-xs">返回</span>
         </button>
         <h2 className="text-sm font-semibold text-gray-800 flex-1">历史记录</h2>
         <span className="text-xs text-gray-400">{records.length} 条</span>
@@ -152,7 +155,7 @@ export const HistoryPanel = memo<HistoryPanelProps>(({ onBack }) => {
 
       {/* 复制成功提示 - 固定在顶部 */}
       {copiedId && (
-        <div className="absolute top-14 left-1/2 -translate-x-1/2 bg-green-500 text-white text-xs px-3 py-1.5 rounded-full shadow-lg z-50 animate-bounce">
+        <div className="absolute top-20 left-1/2 -translate-x-1/2 bg-green-500 text-white text-xs px-3 py-1.5 rounded-full shadow-lg z-50 animate-bounce">
           已复制到剪贴板
         </div>
       )}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,4 +1,5 @@
 import type { SpeechTideState, ShortcutConfig } from '../shared/app-state'
+import type { ConversationRecord } from '../shared/conversation'
 
 interface TestTranscriptionResult {
   text: string
@@ -89,6 +90,9 @@ declare global {
       playTestAudio: () => Promise<{ success: boolean; error?: string }>
       getHistoryStats: (options?: { maxAgeDays?: number }) => Promise<{ count: number; sizeBytes: number; error?: string }>
       clearHistory: (options?: { maxAgeDays?: number }) => Promise<{ success: boolean; deletedCount?: number; error?: string }>
+      getHistoryList: (options?: { limit?: number; offset?: number }) => Promise<{ records: ConversationRecord[]; error?: string }>
+      deleteHistoryItem: (sessionId: string) => Promise<{ success: boolean; error?: string }>
+      playHistoryAudio: (sessionId: string) => Promise<{ success: boolean; error?: string }>
       onPlayAudio: (callback: (audioPath: string) => void) => () => void
     }
     onboarding: {


### PR DESCRIPTION
## Summary
- Add history panel as a second-level page accessible from main panel header
- Display transcription records sorted by time (newest first), with copy/play/delete actions
- Click on any record to copy its transcript with visual feedback
- Filter out test records from the list

## Changes
- `electron/storage/conversation-store.ts`: Add `list()`, `get()`, `delete()` methods
- `electron/core/app-controller.ts`: Add IPC handlers for history operations
- `electron/listeners/ipc-listeners.ts`: Register new IPC channels
- `electron/preload.ts`: Expose new APIs to renderer
- `src/components/HistoryPanel.tsx`: New component for history display
- `src/App.tsx`: Add navigation to history panel
- `src/global.d.ts`: Update type declarations

## Test plan
- [x] Click history button in header, verify panel opens
- [x] Verify records are displayed in reverse chronological order
- [x] Click a record to copy, verify "已复制" toast appears
- [x] Click play button to play audio
- [x] Click delete button to remove a record
- [x] Click back button to return to main panel