### PR TITLE
feat: add beta channel support for prerelease updates

### DIFF
--- a/.github/workflows/release-mac-arm64.yml
+++ b/.github/workflows/release-mac-arm64.yml
@@ -48,6 +48,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
+          prerelease: ${{ contains(github.ref, '-beta') }}
           files: |
             release/**/SpeechTide-*-mac-arm64.dmg
             release/**/SpeechTide-*-mac-arm64.dmg.blockmap

--- a/electron/config/index.ts
+++ b/electron/config/index.ts
@@ -174,6 +174,8 @@ export interface AppSettings {
   autoShowOnStart: boolean
   /** 模型缓存 TTL（分钟），0 表示永不过期 */
   cacheTTLMinutes: number
+  /** 是否接收测试版更新（beta 版本） */
+  allowBetaUpdates: boolean
 }
 
 export function loadAppSettings(): AppSettings {
@@ -184,6 +186,7 @@ export function loadAppSettings(): AppSettings {
     notificationEnabled: true,
     autoShowOnStart: false,
     cacheTTLMinutes: 30, // 默认 30 分钟
+    allowBetaUpdates: false, // 默认不接收测试版
   }
   return loadJsonFile<AppSettings>('settings.json', defaults)
 }

--- a/electron/core/app-controller.ts
+++ b/electron/core/app-controller.ts
@@ -101,6 +101,9 @@ export class AppController {
     this.registerNativeRecordingIPC()
     this.setupStateListeners()
 
+    // 应用 beta 更新设置
+    updateService.setAllowBetaUpdates(this.settings.allowBetaUpdates)
+
     this.initialized = true
     metrics.endTimer(initTimer, 'model_load', { stage: 'app_init' })
     logger.info('初始化完成')
@@ -221,6 +224,11 @@ export class AppController {
             if (this.transcriber) {
               this.scheduleTranscriberUnload()
             }
+          }
+
+          // 如果 beta 更新设置变更，更新 UpdateService
+          if (settings.allowBetaUpdates !== undefined) {
+            updateService.setAllowBetaUpdates(settings.allowBetaUpdates)
           }
 
           return { success: true }

--- a/electron/listeners/ipc-listeners.ts
+++ b/electron/listeners/ipc-listeners.ts
@@ -23,6 +23,7 @@ export interface IPCHandlers {
     notificationEnabled: boolean
     autoShowOnStart: boolean
     cacheTTLMinutes: number
+    allowBetaUpdates: boolean
   }>) => Promise<{ success: boolean; error?: string }>
   checkAppleScriptPermission: () => Promise<{
     available: boolean

--- a/electron/services/tray-service.ts
+++ b/electron/services/tray-service.ts
@@ -179,15 +179,17 @@ export class TrayService {
 
     // 有更新时显示更新菜单项
     if (updateInfo?.available && updateInfo.version) {
+      const isBeta = updateInfo.version.includes('-beta')
+      const betaTag = isBeta ? ' (BETA)' : ''
       let label: string
       if (updateInfo.installing) {
-        label = `⏳ 正在安装 v${updateInfo.version}...`
+        label = `⏳ 正在安装 v${updateInfo.version}${betaTag}...`
       } else if (updateInfo.downloading) {
-        label = `⬇️ 正在下载 v${updateInfo.version}...`
+        label = `⬇️ 正在下载 v${updateInfo.version}${betaTag}...`
       } else if (updateInfo.downloaded) {
-        label = `✅ v${updateInfo.version} 已就绪，点击安装`
+        label = `✅ v${updateInfo.version}${betaTag} 已就绪，点击安装`
       } else {
-        label = `🔄 有新版本 v${updateInfo.version} 可用`
+        label = `🔄 有新版本 v${updateInfo.version}${betaTag} 可用`
       }
 
       menuItems.push({

--- a/electron/services/update-service.ts
+++ b/electron/services/update-service.ts
@@ -94,8 +94,8 @@ export class UpdateService {
         const zipPath = path.join(pendingPath, zipFile)
 
         if (fs.existsSync(zipPath)) {
-          // 从文件名提取版本号，如 SpeechTide-1.3.10-mac-arm64.zip
-          const match = zipFile.match(/SpeechTide-([0-9.]+)-/)
+          // 从文件名提取版本号，如 SpeechTide-1.3.10-mac-arm64.zip 或 SpeechTide-1.5.1-beta.0-mac-arm64.zip
+          const match = zipFile.match(/SpeechTide-([0-9.]+(?:-beta\.[0-9]+)?)-/)
           const version = match ? match[1] : 'unknown'
 
           this.state = {

--- a/electron/services/update-service.ts
+++ b/electron/services/update-service.ts
@@ -135,6 +135,14 @@ export class UpdateService {
   }
 
   /**
+   * 设置是否允许接收测试版更新
+   */
+  setAllowBetaUpdates(allow: boolean): void {
+    this.autoUpdater.allowPrerelease = allow
+    logger.info('测试版更新设置已更新', { allowBetaUpdates: allow })
+  }
+
+  /**
    * 配置 autoUpdater
    */
   private configureAutoUpdater(): void {
@@ -144,6 +152,8 @@ export class UpdateService {
     this.autoUpdater.autoInstallOnAppQuit = false
     // 不允许降级
     this.autoUpdater.allowDowngrade = false
+    // 默认不接收预发布版本（beta），需要用户手动开启
+    this.autoUpdater.allowPrerelease = false
 
     // 注册事件监听
     this.autoUpdater.on('checking-for-update', () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,6 +65,7 @@ function App() {
   const [clipboardMode, setClipboardMode] = useState(false)
   const [autoShowOnStart, setAutoShowOnStart] = useState(false)
   const [cacheTTLMinutes, setCacheTTLMinutes] = useState(30)
+  const [allowBetaUpdates, setAllowBetaUpdates] = useState(false)
   const [appleScriptPermission, setAppleScriptPermission] = useState<{
     available: boolean
     hasPermission: boolean
@@ -102,6 +103,7 @@ function App() {
       setAutoShowOnStart(s.autoShowOnStart)
       // 兜底处理：防止配置缺字段或损坏
       setCacheTTLMinutes(Number.isFinite(s.cacheTTLMinutes) ? s.cacheTTLMinutes : 30)
+      setAllowBetaUpdates(s.allowBetaUpdates ?? false)
     })
 
     // 检查 AppleScript 权限
@@ -245,6 +247,15 @@ function App() {
       await window.speech.updateSettings({ cacheTTLMinutes: value })
     } catch (err) {
       console.error('更新缓存时间设置失败:', err)
+    }
+  }
+
+  const updateAllowBetaUpdates = async (value: boolean) => {
+    setAllowBetaUpdates(value)
+    try {
+      await window.speech.updateSettings({ allowBetaUpdates: value })
+    } catch (err) {
+      console.error('更新测试版更新设置失败:', err)
     }
   }
 
@@ -407,6 +418,7 @@ function App() {
             clipboardMode={clipboardMode}
             autoShowOnStart={autoShowOnStart}
             cacheTTLMinutes={cacheTTLMinutes}
+            allowBetaUpdates={allowBetaUpdates}
             appleScriptPermission={appleScriptPermission}
             historyStats={historyStats}
             isClearing={isClearing}
@@ -414,6 +426,7 @@ function App() {
             onUpdateClipboardMode={updateClipboardMode}
             onUpdateAutoShowOnStart={updateAutoShowOnStart}
             onUpdateCacheTTL={updateCacheTTL}
+            onUpdateAllowBetaUpdates={updateAllowBetaUpdates}
             onRefreshAppleScriptPermission={refreshAppleScriptPermission}
             onClearHistory={clearHistory}
             onRefreshHistoryStats={refreshHistoryStats}

--- a/src/components/AppSettings.tsx
+++ b/src/components/AppSettings.tsx
@@ -93,6 +93,7 @@ export const AppSettings = memo<AppSettingsProps>(({
 }) => {
   const [showConfirm, setShowConfirm] = useState(false)
   const [selectedAge, setSelectedAge] = useState(7)
+  const [showBetaWarning, setShowBetaWarning] = useState(false)
 
   const handleToggleClipboard = useCallback(() => {
     onUpdateClipboardMode(!clipboardMode)
@@ -103,8 +104,19 @@ export const AppSettings = memo<AppSettingsProps>(({
   }, [autoShowOnStart, onUpdateAutoShowOnStart])
 
   const handleToggleBeta = useCallback(() => {
-    onUpdateAllowBetaUpdates(!allowBetaUpdates)
+    if (!allowBetaUpdates) {
+      // 启用 beta 时显示警告
+      setShowBetaWarning(true)
+    } else {
+      // 禁用 beta 直接执行
+      onUpdateAllowBetaUpdates(false)
+    }
   }, [allowBetaUpdates, onUpdateAllowBetaUpdates])
+
+  const handleConfirmEnableBeta = useCallback(async () => {
+    setShowBetaWarning(false)
+    await onUpdateAllowBetaUpdates(true)
+  }, [onUpdateAllowBetaUpdates])
 
   const handleCacheTTLChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
     onUpdateCacheTTL(Number(e.target.value))
@@ -141,7 +153,18 @@ export const AppSettings = memo<AppSettingsProps>(({
       <div className="mt-2 divide-y divide-gray-50">
         <Toggle enabled={clipboardMode} onToggle={handleToggleClipboard} label="禁用自动插入" />
         <Toggle enabled={autoShowOnStart} onToggle={handleToggleAutoShow} label="启动时显示面板" />
-        <Toggle enabled={allowBetaUpdates} onToggle={handleToggleBeta} label="接收测试版更新" />
+        <div className="flex items-center justify-between py-1.5">
+          <div className="flex items-center gap-1">
+            <span className="text-xs text-gray-600">接收测试版更新</span>
+            <span className="text-[10px] text-gray-400 cursor-help" title="测试版可能包含未完善的功能和已知问题，仅推荐开发者使用">ⓘ</span>
+          </div>
+          <button
+            onClick={handleToggleBeta}
+            className={`relative w-9 h-5 rounded-full transition-colors ${allowBetaUpdates ? 'bg-blue-500' : 'bg-gray-200'}`}
+          >
+            <span className={`absolute top-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${allowBetaUpdates ? 'left-4' : 'left-0.5'}`} />
+          </button>
+        </div>
         <div className="flex items-center justify-between py-1.5">
           <span className="text-xs text-gray-600">模型缓存时间</span>
           <select
@@ -239,6 +262,30 @@ export const AppSettings = memo<AppSettingsProps>(({
               </div>
             </div>
           )}
+        </div>
+      )}
+
+      {/* Beta 更新警告对话框 */}
+      {showBetaWarning && (
+        <div className="mt-3 p-3 bg-amber-50 border border-amber-200 rounded-lg">
+          <p className="text-xs font-medium text-amber-800 mb-1">⚠️ 测试版更新说明</p>
+          <p className="text-xs text-amber-700 mb-2">
+            测试版可能包含未完善的功能和已知问题，可能影响使用稳定性。建议仅在需要体验最新特性时启用。
+          </p>
+          <div className="flex justify-end gap-2">
+            <button
+              onClick={() => setShowBetaWarning(false)}
+              className="px-2 py-1 text-xs bg-white border border-gray-200 rounded hover:bg-gray-50"
+            >
+              取消
+            </button>
+            <button
+              onClick={handleConfirmEnableBeta}
+              className="px-2 py-1 text-xs bg-amber-500 text-white rounded hover:bg-amber-600"
+            >
+              我知道了，启用
+            </button>
+          </div>
         </div>
       )}
     </div>

--- a/src/components/AppSettings.tsx
+++ b/src/components/AppSettings.tsx
@@ -57,6 +57,7 @@ interface AppSettingsProps {
   clipboardMode: boolean
   autoShowOnStart: boolean
   cacheTTLMinutes: number
+  allowBetaUpdates: boolean
   appleScriptPermission: AppleScriptPermission | null
   historyStats: HistoryStats | null
   isClearing: boolean
@@ -64,6 +65,7 @@ interface AppSettingsProps {
   onUpdateClipboardMode: (value: boolean) => Promise<void>
   onUpdateAutoShowOnStart: (value: boolean) => Promise<void>
   onUpdateCacheTTL: (value: number) => Promise<void>
+  onUpdateAllowBetaUpdates: (value: boolean) => Promise<void>
   onRefreshAppleScriptPermission: () => Promise<void>
   onClearHistory: (maxAgeDays: number) => Promise<void>
   onRefreshHistoryStats: (maxAgeDays: number) => Promise<void>
@@ -76,6 +78,7 @@ export const AppSettings = memo<AppSettingsProps>(({
   clipboardMode,
   autoShowOnStart,
   cacheTTLMinutes,
+  allowBetaUpdates,
   appleScriptPermission,
   historyStats,
   isClearing,
@@ -83,6 +86,7 @@ export const AppSettings = memo<AppSettingsProps>(({
   onUpdateClipboardMode,
   onUpdateAutoShowOnStart,
   onUpdateCacheTTL,
+  onUpdateAllowBetaUpdates,
   onRefreshAppleScriptPermission,
   onClearHistory,
   onRefreshHistoryStats,
@@ -97,6 +101,10 @@ export const AppSettings = memo<AppSettingsProps>(({
   const handleToggleAutoShow = useCallback(() => {
     onUpdateAutoShowOnStart(!autoShowOnStart)
   }, [autoShowOnStart, onUpdateAutoShowOnStart])
+
+  const handleToggleBeta = useCallback(() => {
+    onUpdateAllowBetaUpdates(!allowBetaUpdates)
+  }, [allowBetaUpdates, onUpdateAllowBetaUpdates])
 
   const handleCacheTTLChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
     onUpdateCacheTTL(Number(e.target.value))
@@ -133,6 +141,7 @@ export const AppSettings = memo<AppSettingsProps>(({
       <div className="mt-2 divide-y divide-gray-50">
         <Toggle enabled={clipboardMode} onToggle={handleToggleClipboard} label="禁用自动插入" />
         <Toggle enabled={autoShowOnStart} onToggle={handleToggleAutoShow} label="启动时显示面板" />
+        <Toggle enabled={allowBetaUpdates} onToggle={handleToggleBeta} label="接收测试版更新" />
         <div className="flex items-center justify-between py-1.5">
           <span className="text-xs text-gray-600">模型缓存时间</span>
           <select

--- a/src/components/AppSettings.tsx
+++ b/src/components/AppSettings.tsx
@@ -150,34 +150,69 @@ export const AppSettings = memo<AppSettingsProps>(({
     <div className="bg-white rounded-xl border border-gray-100 shadow-sm p-3">
       <span className="text-xs font-medium text-gray-600">设置</span>
 
-      <div className="mt-2 divide-y divide-gray-50">
-        <Toggle enabled={clipboardMode} onToggle={handleToggleClipboard} label="禁用自动插入" />
-        <Toggle enabled={autoShowOnStart} onToggle={handleToggleAutoShow} label="启动时显示面板" />
-        <div className="flex items-center justify-between py-1.5">
-          <div className="flex items-center gap-1">
-            <span className="text-xs text-gray-600">接收测试版更新</span>
-            <span className="text-[10px] text-gray-400 cursor-help" title="测试版可能包含未完善的功能和已知问题，仅推荐开发者使用">ⓘ</span>
+      <div className="mt-2 space-y-2">
+        <div className="divide-y divide-gray-50">
+          <Toggle enabled={clipboardMode} onToggle={handleToggleClipboard} label="禁用自动插入" />
+          <Toggle enabled={autoShowOnStart} onToggle={handleToggleAutoShow} label="启动时显示面板" />
+          <div className="flex items-center justify-between py-1.5">
+            <div className="flex items-center gap-1">
+              <span className="text-xs text-gray-600">接收测试版更新</span>
+              <span
+                className="text-[10px] text-gray-400 cursor-help"
+                title="测试版可能包含未完善的功能和已知问题，仅推荐开发者使用"
+                role="tooltip"
+              >
+                ⓘ
+              </span>
+            </div>
+            <button
+              onClick={handleToggleBeta}
+              className={`relative w-9 h-5 rounded-full transition-colors ${allowBetaUpdates ? 'bg-blue-500' : 'bg-gray-200'}`}
+            >
+              <span className={`absolute top-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${allowBetaUpdates ? 'left-4' : 'left-0.5'}`} />
+            </button>
           </div>
-          <button
-            onClick={handleToggleBeta}
-            className={`relative w-9 h-5 rounded-full transition-colors ${allowBetaUpdates ? 'bg-blue-500' : 'bg-gray-200'}`}
-          >
-            <span className={`absolute top-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${allowBetaUpdates ? 'left-4' : 'left-0.5'}`} />
-          </button>
         </div>
-        <div className="flex items-center justify-between py-1.5">
-          <span className="text-xs text-gray-600">模型缓存时间</span>
-          <select
-            value={cacheTTLMinutes}
-            onChange={handleCacheTTLChange}
-            className="text-xs bg-gray-50 border border-gray-200 rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-blue-400"
-          >
-            {CACHE_TTL_OPTIONS.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
+
+        {/* Beta 更新警告对话框 - 紧跟在开关下方 */}
+        {showBetaWarning && (
+          <div className="p-3 bg-amber-50 border border-amber-200 rounded-lg">
+            <p className="text-xs font-medium text-amber-800 mb-1">⚠️ 测试版更新说明</p>
+            <p className="text-xs text-amber-700 mb-2">
+              测试版可能包含未完善的功能和已知问题，可能影响使用稳定性。建议仅在需要体验最新特性时启用。
+            </p>
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => setShowBetaWarning(false)}
+                className="px-2 py-1 text-xs bg-white border border-gray-200 rounded hover:bg-gray-50"
+              >
+                取消
+              </button>
+              <button
+                onClick={handleConfirmEnableBeta}
+                className="px-2 py-1 text-xs bg-amber-500 text-white rounded hover:bg-amber-600"
+              >
+                我知道了，启用
+              </button>
+            </div>
+          </div>
+        )}
+
+        <div className="divide-y divide-gray-50">
+          <div className="flex items-center justify-between py-1.5">
+            <span className="text-xs text-gray-600">模型缓存时间</span>
+            <select
+              value={cacheTTLMinutes}
+              onChange={handleCacheTTLChange}
+              className="text-xs bg-gray-50 border border-gray-200 rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-blue-400"
+            >
+              {CACHE_TTL_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
         </div>
       </div>
 
@@ -262,30 +297,6 @@ export const AppSettings = memo<AppSettingsProps>(({
               </div>
             </div>
           )}
-        </div>
-      )}
-
-      {/* Beta 更新警告对话框 */}
-      {showBetaWarning && (
-        <div className="mt-3 p-3 bg-amber-50 border border-amber-200 rounded-lg">
-          <p className="text-xs font-medium text-amber-800 mb-1">⚠️ 测试版更新说明</p>
-          <p className="text-xs text-amber-700 mb-2">
-            测试版可能包含未完善的功能和已知问题，可能影响使用稳定性。建议仅在需要体验最新特性时启用。
-          </p>
-          <div className="flex justify-end gap-2">
-            <button
-              onClick={() => setShowBetaWarning(false)}
-              className="px-2 py-1 text-xs bg-white border border-gray-200 rounded hover:bg-gray-50"
-            >
-              取消
-            </button>
-            <button
-              onClick={handleConfirmEnableBeta}
-              className="px-2 py-1 text-xs bg-amber-500 text-white rounded hover:bg-amber-600"
-            >
-              我知道了，启用
-            </button>
-          </div>
         </div>
       )}
     </div>

--- a/src/components/UpdateStatus.tsx
+++ b/src/components/UpdateStatus.tsx
@@ -66,13 +66,26 @@ export const UpdateStatus = memo(() => {
     return `${bytesPerSecond} B/s`
   }
 
+  // 检测是否为 beta 版本
+  const isBetaVersion = (version?: string) => version?.includes('-beta') || false
+
+  // Beta 标识组件
+  const BetaBadge = () => (
+    <span className="ml-1 px-1 py-0.5 text-[10px] bg-orange-500 text-white rounded font-medium">
+      BETA
+    </span>
+  )
+
   return (
     <div className="flex items-center justify-between text-xs text-gray-400 px-1 py-2 border-t border-gray-100">
       <div className="flex items-center gap-2 flex-1 min-w-0">
         {/* 空闲 */}
         {status === 'idle' && (
           <>
-            <span className="text-gray-500">v{currentVersion}</span>
+            <span className="text-gray-500 flex items-center">
+              v{currentVersion}
+              {isBetaVersion(currentVersion) && <BetaBadge />}
+            </span>
             <button
               onClick={handleCheck}
               className="text-blue-500 hover:text-blue-600"
@@ -85,7 +98,10 @@ export const UpdateStatus = memo(() => {
         {/* 检查中 */}
         {status === 'checking' && (
           <>
-            <span className="text-gray-500">v{currentVersion}</span>
+            <span className="text-gray-500 flex items-center">
+              v{currentVersion}
+              {isBetaVersion(currentVersion) && <BetaBadge />}
+            </span>
             <span className="flex items-center gap-1 text-blue-500">
               <span className="animate-spin w-3 h-3 border border-blue-500 border-t-transparent rounded-full" />
               检查中...
@@ -96,7 +112,10 @@ export const UpdateStatus = memo(() => {
         {/* 已是最新 */}
         {status === 'not-available' && (
           <>
-            <span className="text-gray-500">v{currentVersion}</span>
+            <span className="text-gray-500 flex items-center">
+              v{currentVersion}
+              {isBetaVersion(currentVersion) && <BetaBadge />}
+            </span>
             <span className="text-green-500">✓ 已是最新</span>
             <button
               onClick={handleCheck}
@@ -110,9 +129,15 @@ export const UpdateStatus = memo(() => {
         {/* 有可用更新 */}
         {status === 'available' && (
           <>
-            <span className="text-gray-500">v{currentVersion}</span>
+            <span className="text-gray-500 flex items-center">
+              v{currentVersion}
+              {isBetaVersion(currentVersion) && <BetaBadge />}
+            </span>
             <span className="text-gray-400">→</span>
-            <span className="text-green-600 font-medium">v{availableVersion}</span>
+            <span className="text-green-600 font-medium flex items-center">
+              v{availableVersion}
+              {isBetaVersion(availableVersion) && <BetaBadge />}
+            </span>
             <button
               onClick={handleDownload}
               className="px-2 py-0.5 bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors"
@@ -139,7 +164,10 @@ export const UpdateStatus = memo(() => {
         {/* 下载完成 */}
         {status === 'downloaded' && (
           <>
-            <span className="text-green-600">v{availableVersion} 已就绪</span>
+            <span className="text-green-600 flex items-center">
+              v{availableVersion} 已就绪
+              {isBetaVersion(availableVersion) && <BetaBadge />}
+            </span>
             <button
               onClick={handleInstall}
               className="px-2 py-0.5 bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors"
@@ -160,7 +188,10 @@ export const UpdateStatus = memo(() => {
         {/* 错误 */}
         {status === 'error' && (
           <>
-            <span className="text-gray-500">v{currentVersion}</span>
+            <span className="text-gray-500 flex items-center">
+              v{currentVersion}
+              {isBetaVersion(currentVersion) && <BetaBadge />}
+            </span>
             <span className="text-red-500 truncate max-w-[120px]" title={state.error}>
               更新失败
             </span>

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -84,8 +84,8 @@ declare global {
       testTranscription: () => Promise<{ success: boolean; data?: TestTranscriptionResult; error?: string }>
       updateShortcut: (shortcut: ShortcutConfig) => Promise<{ success: boolean; error?: string }>
       setShortcutRecording: (recording: boolean) => Promise<void>
-      getSettings: () => Promise<{ shortcut: ShortcutConfig; autoInsertText: boolean; clipboardMode: boolean; notificationEnabled: boolean; autoShowOnStart: boolean; cacheTTLMinutes: number }>
-      updateSettings: (settings: Partial<{ autoInsertText: boolean; clipboardMode: boolean; notificationEnabled: boolean; autoShowOnStart: boolean; cacheTTLMinutes: number }>) => Promise<{ success: boolean; error?: string }>
+      getSettings: () => Promise<{ shortcut: ShortcutConfig; autoInsertText: boolean; clipboardMode: boolean; notificationEnabled: boolean; autoShowOnStart: boolean; cacheTTLMinutes: number; allowBetaUpdates: boolean }>
+      updateSettings: (settings: Partial<{ autoInsertText: boolean; clipboardMode: boolean; notificationEnabled: boolean; autoShowOnStart: boolean; cacheTTLMinutes: number; allowBetaUpdates: boolean }>) => Promise<{ success: boolean; error?: string }>
       checkAppleScriptPermission: () => Promise<{ available: boolean; hasPermission: boolean; message: string; guide?: string }>
       playTestAudio: () => Promise<{ success: boolean; error?: string }>
       getHistoryStats: (options?: { maxAgeDays?: number }) => Promise<{ count: number; sizeBytes: number; error?: string }>


### PR DESCRIPTION
## Summary
Add support for beta channel updates, allowing users to opt-in to receive prerelease versions.

## Changes

### 1. GitHub Actions Workflow
- Added `prerelease: ${{ contains(github.ref, '-beta') }}` to automatically detect and mark beta releases
- Beta versions (e.g., `v1.5.1-beta.0`) will now be tagged as Pre-release on GitHub
- Stable users won't receive beta update notifications

### 2. Settings Panel
- Added "接收测试版更新" (Receive Beta Updates) toggle in AppSettings
- Default: disabled (users must manually opt-in)
- Setting persisted in `settings.json`

### 3. Backend Implementation
- **AppSettings interface**: Added `allowBetaUpdates: boolean` field
- **UpdateService**: New `setAllowBetaUpdates()` method to control `autoUpdater.allowPrerelease`
- **App initialization**: Applies beta setting from config on startup
- **Settings update**: Propagates changes to UpdateService in real-time

### 4. Data Flow
```
User toggles "接收测试版更新"
  ↓
App.tsx → updateAllowBetaUpdates()
  ↓
IPC: window.speech.updateSettings({ allowBetaUpdates })
  ↓
app-controller.ts → saveAppSettings()
  ↓
updateService.setAllowBetaUpdates()
  ↓
autoUpdater.allowPrerelease = true/false
```

## Files Modified
- `.github/workflows/release-mac-arm64.yml` - Auto-detect prerelease tags
- `electron/config/index.ts` - Add allowBetaUpdates to AppSettings
- `electron/services/update-service.ts` - Implement setAllowBetaUpdates()
- `electron/core/app-controller.ts` - Apply setting on init and update
- `src/global.d.ts` - Update IPC type definitions
- `src/App.tsx` - Add state and handler for beta setting
- `src/components/AppSettings.tsx` - Add toggle UI

## Usage

### Publishing Beta Versions
```bash
npm version prerelease --preid=beta  # v1.5.1-beta.0
git push origin HEAD --follow-tags
```

### User Experience
- **Stable users**: Only receive stable releases (default)
- **Beta testers**: Enable toggle to receive prerelease updates
- **Beta releases**: Clearly marked as "Pre-release" on GitHub

## Test Plan
- [x] Lint passed (除了已存在的 dependency-checker.ts 警告)
- [ ] Test toggle in settings panel
- [ ] Verify setting persists after restart
- [ ] Test beta version detection with actual release