### PR TITLE
feat: warm sand theme with unified orange accent

### DIFF
--- a/src/components/AppSettings.tsx
+++ b/src/components/AppSettings.tsx
@@ -86,7 +86,7 @@ export const AppSettings = memo<AppSettingsProps>(({
       <span className="text-xs text-gray-600">{label}</span>
       <button
         onClick={onToggle}
-        className={`relative w-9 h-5 rounded-full transition-colors ${enabled ? 'bg-blue-500' : 'bg-gray-200'}`}
+        className={`relative w-9 h-5 rounded-full transition-colors ${enabled ? 'bg-[hsl(var(--primary))]' : 'bg-gray-200'}`}
       >
         <span className={`absolute top-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${enabled ? 'left-4' : 'left-0.5'}`} />
       </button>
@@ -113,7 +113,7 @@ export const AppSettings = memo<AppSettingsProps>(({
             </div>
             <button
               onClick={handleToggleBeta}
-              className={`relative w-9 h-5 rounded-full transition-colors ${allowBetaUpdates ? 'bg-blue-500' : 'bg-gray-200'}`}
+              className={`relative w-9 h-5 rounded-full transition-colors ${allowBetaUpdates ? 'bg-[hsl(var(--primary))]' : 'bg-gray-200'}`}
             >
               <span className={`absolute top-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${allowBetaUpdates ? 'left-4' : 'left-0.5'}`} />
             </button>
@@ -150,7 +150,7 @@ export const AppSettings = memo<AppSettingsProps>(({
             <select
               value={cacheTTLMinutes}
               onChange={handleCacheTTLChange}
-              className="text-xs bg-gray-50 border border-gray-200 rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-blue-400"
+              className="text-xs bg-gray-50 border border-gray-200 rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-[hsl(var(--primary))]"
             >
               {CACHE_TTL_OPTIONS.map((opt) => (
                 <option key={opt.value} value={opt.value}>

--- a/src/components/Onboarding/CompleteStep.tsx
+++ b/src/components/Onboarding/CompleteStep.tsx
@@ -24,8 +24,8 @@ export function CompleteStep({ onFinish }: CompleteStepProps) {
         
         <div className="w-full max-w-xs space-y-3 mb-6">
           <div className="flex items-center gap-3 bg-white rounded-xl p-3 shadow-sm border border-gray-100">
-            <div className="w-10 h-10 bg-blue-100 rounded-lg flex items-center justify-center">
-              <span className="text-blue-600 font-bold text-sm">1</span>
+            <div className="w-10 h-10 bg-orange-100 rounded-lg flex items-center justify-center">
+              <span className="text-orange-600 font-bold text-sm">1</span>
             </div>
             <div className="text-left flex-1">
               <p className="text-sm text-gray-700">

--- a/src/components/Onboarding/ModelStep.tsx
+++ b/src/components/Onboarding/ModelStep.tsx
@@ -81,15 +81,15 @@ export function ModelStep({ onNext, onBack, onSkip }: ModelStepProps) {
 
   if (checking) {
     return (
-      <div className="p-6 flex flex-col h-full items-center justify-center bg-gradient-to-b from-blue-50 to-white">
-        <div className="animate-spin w-8 h-8 border-3 border-blue-500 border-t-transparent rounded-full mb-4" />
+      <div className="p-6 flex flex-col h-full items-center justify-center bg-gradient-to-b from-orange-50 to-white">
+        <div className="animate-spin w-8 h-8 border-3 border-[hsl(var(--primary))] border-t-transparent rounded-full mb-4" />
         <p className="text-gray-500 text-sm">正在检查模型...</p>
       </div>
     )
   }
 
   return (
-    <div className="p-6 flex flex-col h-full bg-gradient-to-b from-blue-50 to-white">
+    <div className="p-6 flex flex-col h-full bg-gradient-to-b from-orange-50 to-white">
       <div className="flex-1">
         <div className="text-center mb-6">
           <div className="w-16 h-16 bg-gradient-to-br from-purple-500 to-purple-600 rounded-2xl flex items-center justify-center mx-auto mb-4 shadow-lg">
@@ -132,7 +132,7 @@ export function ModelStep({ onNext, onBack, onSkip }: ModelStepProps) {
               </div>
               <div className="w-full bg-gray-200 rounded-full h-2 overflow-hidden">
                 <div
-                  className="bg-gradient-to-r from-blue-500 to-purple-500 h-2 rounded-full transition-all duration-300"
+                  className="bg-gradient-to-r from-orange-500 to-amber-500 h-2 rounded-full transition-all duration-300"
                   style={{ width: `${progress.percent}%` }}
                 />
               </div>
@@ -147,7 +147,7 @@ export function ModelStep({ onNext, onBack, onSkip }: ModelStepProps) {
               className={`w-full mt-3 py-2.5 rounded-lg font-medium transition-colors ${
                 downloading
                   ? 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-                  : 'bg-gradient-to-r from-blue-500 to-purple-500 text-white hover:opacity-90'
+                  : 'bg-gradient-to-r from-orange-500 to-amber-500 text-white hover:opacity-90'
               }`}
             >
               {downloading ? '取消下载' : '开始下载'}
@@ -194,7 +194,7 @@ export function ModelStep({ onNext, onBack, onSkip }: ModelStepProps) {
             disabled={!downloaded || downloading}
             className={`px-6 py-2 rounded-xl font-medium transition-colors ${
               downloaded && !downloading
-                ? 'bg-blue-500 text-white hover:bg-blue-600 shadow-sm' 
+                ? 'bg-[hsl(var(--primary))] text-white hover:opacity-90 shadow-sm' 
                 : 'bg-gray-200 text-gray-400 cursor-not-allowed'
             }`}
           >

--- a/src/components/Onboarding/PermissionsStep.tsx
+++ b/src/components/Onboarding/PermissionsStep.tsx
@@ -63,15 +63,15 @@ export function PermissionsStep({ onNext, onBack, onSkip }: PermissionsStepProps
 
   if (checking) {
     return (
-      <div className="p-6 flex flex-col h-full items-center justify-center bg-gradient-to-b from-blue-50 to-white">
-        <div className="animate-spin w-8 h-8 border-3 border-blue-500 border-t-transparent rounded-full mb-4" />
+      <div className="p-6 flex flex-col h-full items-center justify-center bg-gradient-to-b from-orange-50 to-white">
+        <div className="animate-spin w-8 h-8 border-3 border-[hsl(var(--primary))] border-t-transparent rounded-full mb-4" />
         <p className="text-gray-500 text-sm">正在检查权限...</p>
       </div>
     )
   }
 
   return (
-    <div className="p-6 flex flex-col h-full bg-gradient-to-b from-blue-50 to-white">
+    <div className="p-6 flex flex-col h-full bg-gradient-to-b from-orange-50 to-white">
       <div className="flex-1">
         <div className="text-center mb-6">
           <div className="w-16 h-16 bg-gradient-to-br from-green-500 to-green-600 rounded-2xl flex items-center justify-center mx-auto mb-4 shadow-lg">
@@ -110,7 +110,7 @@ export function PermissionsStep({ onNext, onBack, onSkip }: PermissionsStepProps
                 <button
                   onClick={microphone === 'denied' ? () => window.onboarding.openMicrophoneSettings() : requestMicrophone}
                   disabled={requesting === 'microphone'}
-                  className="px-4 py-2 bg-blue-500 text-white text-sm rounded-lg hover:bg-blue-600 disabled:opacity-50 transition-colors"
+                  className="px-4 py-2 bg-[hsl(var(--primary))] text-white text-sm rounded-lg hover:opacity-90 disabled:opacity-50 transition-colors"
                 >
                   {requesting === 'microphone' ? '...' : microphone === 'denied' ? '设置' : '授权'}
                 </button>
@@ -184,7 +184,7 @@ export function PermissionsStep({ onNext, onBack, onSkip }: PermissionsStepProps
             disabled={!canProceed}
             className={`px-6 py-2 rounded-xl font-medium transition-colors ${
               canProceed 
-                ? 'bg-blue-500 text-white hover:bg-blue-600 shadow-sm' 
+                ? 'bg-[hsl(var(--primary))] text-white hover:opacity-90 shadow-sm' 
                 : 'bg-gray-200 text-gray-400 cursor-not-allowed'
             }`}
           >

--- a/src/components/Onboarding/WelcomeStep.tsx
+++ b/src/components/Onboarding/WelcomeStep.tsx
@@ -9,9 +9,9 @@ interface WelcomeStepProps {
 
 export function WelcomeStep({ onNext, onSkip }: WelcomeStepProps) {
   return (
-    <div className="p-6 flex flex-col h-full bg-gradient-to-b from-blue-50 to-white">
+    <div className="p-6 flex flex-col h-full bg-gradient-to-b from-orange-50 to-white">
       <div className="flex-1 flex flex-col items-center justify-center text-center">
-        <div className="w-20 h-20 bg-gradient-to-br from-blue-500 to-blue-600 rounded-2xl flex items-center justify-center mb-6 shadow-lg">
+        <div className="w-20 h-20 bg-gradient-to-br from-orange-500 to-amber-500 rounded-2xl flex items-center justify-center mb-6 shadow-lg">
           <span className="text-4xl">🎙️</span>
         </div>
         <h1 className="text-2xl font-bold text-gray-800 mb-2">欢迎使用 SpeechTide</h1>
@@ -21,7 +21,7 @@ export function WelcomeStep({ onNext, onSkip }: WelcomeStepProps) {
         
         <div className="w-full max-w-xs space-y-3 mb-8">
           <div className="flex items-center gap-3 bg-white rounded-xl p-3 shadow-sm border border-gray-100">
-            <div className="w-10 h-10 bg-blue-100 rounded-lg flex items-center justify-center text-lg">🎤</div>
+            <div className="w-10 h-10 bg-orange-100 rounded-lg flex items-center justify-center text-lg">🎤</div>
             <div className="text-left">
               <p className="text-sm font-medium text-gray-700">授权麦克风</p>
               <p className="text-xs text-gray-400">录制您的语音</p>
@@ -47,7 +47,7 @@ export function WelcomeStep({ onNext, onSkip }: WelcomeStepProps) {
       <div className="flex flex-col gap-3">
         <button
           onClick={onNext}
-          className="w-full py-3 bg-blue-500 text-white rounded-xl hover:bg-blue-600 transition-colors font-medium shadow-sm"
+          className="w-full py-3 bg-[hsl(var(--primary))] text-white rounded-xl hover:opacity-90 transition-colors font-medium shadow-sm"
         >
           开始设置
         </button>

--- a/src/components/Onboarding/index.tsx
+++ b/src/components/Onboarding/index.tsx
@@ -60,7 +60,7 @@ export function Onboarding({ onComplete }: OnboardingProps) {
     return (
       <div className="h-full flex items-center justify-center bg-slate-50">
         <div className="text-center">
-          <div className="animate-spin w-8 h-8 border-4 border-blue-500 border-t-transparent rounded-full mx-auto mb-4" />
+          <div className="animate-spin w-8 h-8 border-4 border-[hsl(var(--primary))] border-t-transparent rounded-full mx-auto mb-4" />
           <p className="text-gray-600">正在加载...</p>
         </div>
       </div>

--- a/src/components/ShortcutSettings.tsx
+++ b/src/components/ShortcutSettings.tsx
@@ -135,7 +135,7 @@ export const ShortcutSettings = ({
           onBlur={handleInputBlur}
           className={`w-full mt-2 px-3 py-2 text-xs text-center font-mono border rounded-lg bg-gray-50 cursor-pointer focus:outline-none transition-all ${
             isRecordingShortcut
-              ? 'border-blue-400 ring-2 ring-blue-100 bg-blue-50'
+              ? 'border-orange-400 ring-2 ring-orange-100 bg-orange-50'
               : 'border-gray-200 hover:border-gray-300'
           }`}
           placeholder="点击设置"
@@ -152,7 +152,7 @@ export const ShortcutSettings = ({
               onClick={() => handleModeChange(option.value)}
               className={`flex-1 px-2 py-1.5 text-xs rounded-lg border transition-all ${
                 currentMode === option.value
-                  ? 'bg-blue-50 border-blue-300 text-blue-700 font-medium'
+                  ? 'bg-orange-50 border-orange-300 text-orange-700 font-medium'
                   : 'bg-gray-50 border-gray-200 text-gray-600 hover:border-gray-300'
               }`}
             >

--- a/src/components/TestTranscription.tsx
+++ b/src/components/TestTranscription.tsx
@@ -70,7 +70,7 @@ export const TestTranscription = ({
           <button
             onClick={onRunTest}
             disabled={isDisabled}
-            className="text-xs px-2 py-1 rounded-md bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-50 transition-colors"
+            className="text-xs px-2 py-1 rounded-md bg-[hsl(var(--primary))] text-white hover:opacity-90 disabled:opacity-50 transition-colors"
           >
             {testRunning ? '转录中...' : '开始测试'}
           </button>
@@ -89,7 +89,7 @@ export const TestTranscription = ({
             <button
               onClick={onCopyTestResult}
               className={`text-xs px-1.5 py-0.5 rounded transition-colors ${
-                testCopySuccess ? 'text-green-600' : 'text-blue-600 hover:bg-blue-50'
+                testCopySuccess ? 'text-green-600' : 'text-[hsl(var(--primary))] hover:bg-orange-50'
               }`}
             >
               {testCopySuccess ? '✓' : '复制'}

--- a/src/components/TranscriptionCard.tsx
+++ b/src/components/TranscriptionCard.tsx
@@ -30,7 +30,7 @@ export const TranscriptionCard = memo<TranscriptionCardProps>(({
             copySuccess
               ? 'text-green-600 bg-green-50'
               : transcript
-                ? 'text-blue-600 hover:bg-blue-50'
+                ? 'text-[hsl(var(--primary))] hover:bg-orange-50'
                 : 'text-gray-300 cursor-not-allowed'
           }`}
         >

--- a/src/components/UpdateStatus.tsx
+++ b/src/components/UpdateStatus.tsx
@@ -88,7 +88,7 @@ export const UpdateStatus = memo(() => {
             </span>
             <button
               onClick={handleCheck}
-              className="text-blue-500 hover:text-blue-600"
+              className="text-[hsl(var(--primary))] hover:opacity-80"
             >
               检查更新
             </button>
@@ -102,8 +102,8 @@ export const UpdateStatus = memo(() => {
               v{currentVersion}
               {isBetaVersion(currentVersion) && <BetaBadge />}
             </span>
-            <span className="flex items-center gap-1 text-blue-500">
-              <span className="animate-spin w-3 h-3 border border-blue-500 border-t-transparent rounded-full" />
+            <span className="flex items-center gap-1 text-[hsl(var(--primary))]">
+              <span className="animate-spin w-3 h-3 border border-[hsl(var(--primary))] border-t-transparent rounded-full" />
               检查中...
             </span>
           </>
@@ -119,7 +119,7 @@ export const UpdateStatus = memo(() => {
             <span className="text-green-500">✓ 已是最新</span>
             <button
               onClick={handleCheck}
-              className="text-gray-400 hover:text-blue-500"
+              className="text-gray-400 hover:text-[hsl(var(--primary))]"
             >
               再次检查
             </button>
@@ -140,7 +140,7 @@ export const UpdateStatus = memo(() => {
             </span>
             <button
               onClick={handleDownload}
-              className="px-2 py-0.5 bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors"
+              className="px-2 py-0.5 bg-[hsl(var(--primary))] text-white rounded hover:opacity-90 transition-colors"
             >
               更新
             </button>
@@ -150,10 +150,10 @@ export const UpdateStatus = memo(() => {
         {/* 下载中 */}
         {status === 'downloading' && progress && (
           <div className="flex items-center gap-2 flex-1">
-            <span className="text-blue-500">下载中 {progress.percent.toFixed(0)}%</span>
+            <span className="text-[hsl(var(--primary))]">下载中 {progress.percent.toFixed(0)}%</span>
             <div className="flex-1 h-1 bg-gray-200 rounded-full overflow-hidden max-w-[80px]">
               <div
-                className="h-full bg-blue-500 transition-all duration-300"
+                className="h-full bg-[hsl(var(--primary))] transition-all duration-300"
                 style={{ width: `${progress.percent}%` }}
               />
             </div>
@@ -170,7 +170,7 @@ export const UpdateStatus = memo(() => {
             </span>
             <button
               onClick={handleInstall}
-              className="px-2 py-0.5 bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors"
+              className="px-2 py-0.5 bg-[hsl(var(--primary))] text-white rounded hover:opacity-90 transition-colors"
             >
               重启安装
             </button>
@@ -179,8 +179,8 @@ export const UpdateStatus = memo(() => {
 
         {/* 安装中 */}
         {status === 'installing' && (
-          <span className="flex items-center gap-1 text-blue-500">
-            <span className="animate-spin w-3 h-3 border border-blue-500 border-t-transparent rounded-full" />
+          <span className="flex items-center gap-1 text-[hsl(var(--primary))]">
+            <span className="animate-spin w-3 h-3 border border-[hsl(var(--primary))] border-t-transparent rounded-full" />
             正在安装...
           </span>
         )}
@@ -197,7 +197,7 @@ export const UpdateStatus = memo(() => {
             </span>
             <button
               onClick={handleCheck}
-              className="text-blue-500 hover:text-blue-600"
+              className="text-[hsl(var(--primary))] hover:opacity-80"
             >
               重试
             </button>
@@ -208,7 +208,7 @@ export const UpdateStatus = memo(() => {
       {/* 去官网下载链接 */}
       <button
         onClick={handleOpenReleasePage}
-        className="text-gray-400 hover:text-blue-500 ml-2 shrink-0"
+        className="text-gray-400 hover:text-[hsl(var(--primary))] ml-2 shrink-0"
       >
         去官网下载
       </button>

--- a/src/index.css
+++ b/src/index.css
@@ -13,33 +13,33 @@
   }
 
   :root {
-    /* Warm minimal palette */
-    --background: 40 20% 98%;
-    --foreground: 30 10% 15%;
+    /* 暖砂调色板 - 橙色主色，暖灰底色 */
+    --background: 30 6% 98%;
+    --foreground: 24 10% 10%;
     --card: 0 0% 100%;
-    --card-foreground: 30 10% 15%;
+    --card-foreground: 24 10% 10%;
     --popover: 0 0% 100%;
-    --popover-foreground: 30 10% 15%;
-    --primary: 220 70% 50%;
+    --popover-foreground: 24 10% 10%;
+    --primary: 25 95% 53%;
     --primary-foreground: 0 0% 100%;
-    --secondary: 35 25% 93%;
-    --secondary-foreground: 30 10% 25%;
-    --muted: 40 15% 94%;
-    --muted-foreground: 30 8% 55%;
-    --accent: 25 90% 55%;
-    --accent-foreground: 0 0% 100%;
-    --destructive: 0 72% 55%;
+    --secondary: 30 10% 93%;
+    --secondary-foreground: 24 10% 25%;
+    --muted: 30 6% 94%;
+    --muted-foreground: 24 5% 50%;
+    --accent: 45 93% 47%;
+    --accent-foreground: 24 10% 10%;
+    --destructive: 0 84% 60%;
     --destructive-foreground: 0 0% 100%;
-    --border: 35 15% 88%;
-    --input: 35 15% 88%;
-    --ring: 220 70% 50%;
+    --border: 30 6% 88%;
+    --input: 30 6% 88%;
+    --ring: 25 95% 53%;
     --radius: 0.75rem;
 
     /* Custom additions */
-    --surface: 40 15% 96%;
-    --text-primary: 30 10% 15%;
-    --text-secondary: 30 8% 45%;
-    --text-tertiary: 30 6% 65%;
+    --surface: 30 6% 96%;
+    --text-primary: 24 10% 10%;
+    --text-secondary: 24 5% 45%;
+    --text-tertiary: 24 4% 60%;
   }
 
   * {
@@ -120,7 +120,7 @@
   }
 
   .status-dot.transcribing {
-    @apply bg-blue-500;
+    @apply bg-orange-500;
     animation: pulse-recording 1s ease-in-out infinite;
   }
 


### PR DESCRIPTION
## Summary
- Change primary color from blue to warm orange for unified brand identity
- Reduce yellow tint in background to maintain neutral warmth
- Update transcribing status dot from blue to orange, matching primary color
- Unify color temperature across the entire palette, resolving previous cold/warm conflict

## Changes
| Variable | Old Value | New Value |
|----------|-----------|-----------|
| `--primary` | `220 70% 50%` (blue) | `25 95% 53%` (orange) |
| `--background` | `40 20% 98%` | `30 6% 98%` |
| `--accent` | `25 90% 55%` | `45 93% 47%` (golden) |
| `.status-dot.transcribing` | `blue-500` | `orange-500` |

## Test plan
- [x] Run `npm run dev` to preview main panel
- [x] Verify status colors (idle/recording/transcribing) display correctly
- [x] Confirm buttons, toggles, and interactive elements use correct colors