### PR TITLE
feat: add online transcription support (OpenAI/Groq/Custom)

### DIFF
--- a/electron/config/initializer.ts
+++ b/electron/config/initializer.ts
@@ -28,6 +28,17 @@ const DEFAULT_SETTINGS = {
   notificationEnabled: true,
   autoShowOnStart: true,
   cacheTTLMinutes: 30,
+  transcription: {
+    mode: 'offline',
+    online: {
+      provider: 'openai',
+      apiKey: '',
+      modelId: 'whisper-1',
+      responseFormat: 'json',
+      temperature: 0,
+      timeoutMs: 120000,
+    },
+  },
 }
 
 /** 默认音频配置 */
@@ -37,7 +48,7 @@ const DEFAULT_AUDIO_CONFIG = {
   threshold: 0,
   silence: '10.0',
   recorder: 'sox',
-  maxDurationMs: 60000,
+  maxDurationMs: 0,
 }
 
 /** 默认转写配置 */

--- a/electron/transcriber/index.ts
+++ b/electron/transcriber/index.ts
@@ -1,5 +1,7 @@
 import type { SenseVoiceTranscriberConfig } from '../config'
+import type { OnlineTranscriptionConfig } from '../../shared/app-state'
 import { SenseVoiceTranscriber } from './sensevoice-transcriber'
+import { OpenAITranscriber } from './openai-transcriber'
 
 // 类型定义
 export interface TranscriptionResult {
@@ -14,6 +16,15 @@ export interface Transcriber {
   destroy?(): void
 }
 
-export function createTranscriber(config: SenseVoiceTranscriberConfig, options: { supportDir: string }): Transcriber {
+export interface OpenAITranscriberConfig extends OnlineTranscriptionConfig {
+  engine: 'openai'
+}
+
+export type TranscriberConfig = SenseVoiceTranscriberConfig | OpenAITranscriberConfig
+
+export function createTranscriber(config: TranscriberConfig, options: { supportDir: string }): Transcriber {
+  if (config.engine === 'openai') {
+    return new OpenAITranscriber(config)
+  }
   return new SenseVoiceTranscriber(config, { supportDir: options.supportDir })
 }

--- a/electron/transcriber/openai-transcriber.ts
+++ b/electron/transcriber/openai-transcriber.ts
@@ -1,0 +1,135 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import type { OnlineTranscriptionConfig } from '../../shared/app-state'
+import { TRANSCRIPTION_PROVIDERS } from '../../shared/app-state'
+import type { Transcriber, TranscriptionResult } from './index'
+import { createModuleLogger } from '../utils/logger'
+
+const logger = createModuleLogger('openai-transcriber')
+
+function getDefaultBaseUrl(provider: string): string {
+  const meta = TRANSCRIPTION_PROVIDERS.find(p => p.id === provider)
+  return meta?.defaultBaseUrl || 'https://api.openai.com/v1'
+}
+
+function normalizeBaseUrl(baseUrl: string | undefined, provider: string): string {
+  const trimmed = baseUrl?.trim()
+  if (!trimmed) return getDefaultBaseUrl(provider)
+  return trimmed.replace(/\/+$/, '')
+}
+
+function getTimeoutMs(config: OnlineTranscriptionConfig): number {
+  return Number.isFinite(config.timeoutMs) && (config.timeoutMs as number) > 0
+    ? (config.timeoutMs as number)
+    : 120000
+}
+
+export class OpenAITranscriber implements Transcriber {
+  constructor(private config: OnlineTranscriptionConfig) {}
+
+  updateConfig(config: OnlineTranscriptionConfig): void {
+    this.config = config
+  }
+
+  private isConfigValid(): boolean {
+    return !!(this.config.apiKey && this.config.modelId)
+  }
+
+  async transcribe(filePath: string): Promise<TranscriptionResult> {
+    if (!this.isConfigValid()) {
+      throw new Error('在线转写配置无效：请检查 API Key 和模型 ID')
+    }
+
+    const startTime = Date.now()
+    const baseUrl = normalizeBaseUrl(this.config.baseUrl, this.config.provider)
+    const url = `${baseUrl}/audio/transcriptions`
+
+    logger.info('开始在线转写', { provider: this.config.provider, modelId: this.config.modelId })
+
+    const fileBuffer = await fs.readFile(filePath)
+    const fileName = path.basename(filePath)
+    const file = new File([fileBuffer], fileName, { type: 'audio/wav' })
+
+    const form = new FormData()
+    form.append('file', file)
+    form.append('model', this.config.modelId)
+
+    if (this.config.language) {
+      form.append('language', this.config.language)
+    }
+    if (this.config.responseFormat) {
+      form.append('response_format', this.config.responseFormat)
+    }
+    if (this.config.temperature !== undefined && this.config.temperature !== null) {
+      form.append('temperature', String(this.config.temperature))
+    }
+
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), getTimeoutMs(this.config))
+
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${this.config.apiKey}`,
+        },
+        body: form,
+        signal: controller.signal,
+      })
+
+      if (!response.ok) {
+        const errorText = await response.text()
+        let errorMessage = `API 请求失败: HTTP ${response.status}`
+        try {
+          const parsed = JSON.parse(errorText) as { error?: { message?: string } }
+          if (parsed.error?.message) {
+            errorMessage = parsed.error.message
+          }
+        } catch {
+          // ignore json parse
+        }
+        throw new Error(errorMessage)
+      }
+
+      const durationMs = Date.now() - startTime
+      if (this.config.responseFormat === 'text') {
+        const text = (await response.text()).trim()
+        if (!text) {
+          throw new Error('API 返回空内容')
+        }
+        logger.info('在线转写完成', { durationMs, outputLength: text.length })
+        return {
+          text,
+          modelId: this.config.modelId,
+          durationMs,
+        }
+      }
+
+      const data = await response.json() as { text?: string; language?: string }
+      const text = data.text?.trim()
+      if (!text) {
+        throw new Error('API 返回空内容')
+      }
+
+      logger.info('在线转写完成', { durationMs, outputLength: text.length })
+      return {
+        text,
+        modelId: this.config.modelId,
+        durationMs,
+        language: data.language,
+      }
+    } catch (error) {
+      const durationMs = Date.now() - startTime
+      if (error instanceof Error) {
+        if (error.name === 'AbortError') {
+          throw new Error(`在线转写超时（${Math.round(getTimeoutMs(this.config) / 1000)}秒）`)
+        }
+        logger.error(error, { durationMs })
+        throw error
+      }
+      throw new Error('在线转写失败：未知错误')
+    } finally {
+      clearTimeout(timeoutId)
+    }
+  }
+}

--- a/electron/transcriber/openai-transcriber.ts
+++ b/electron/transcriber/openai-transcriber.ts
@@ -132,4 +132,8 @@ export class OpenAITranscriber implements Transcriber {
       clearTimeout(timeoutId)
     }
   }
+
+  destroy(): void {
+    // No resources to release for HTTP-based transcriber
+  }
 }

--- a/shared/app-state.ts
+++ b/shared/app-state.ts
@@ -57,3 +57,90 @@ export interface PolishConfig {
   timeoutMs: number
   baseUrl?: string
 }
+
+/**
+ * 转录模式
+ */
+export type TranscriptionMode = 'offline' | 'online'
+
+/**
+ * 在线转录 Provider 类型
+ * - openai: OpenAI 官方
+ * - groq: Groq（免费高速）
+ * - custom: 自定义 OpenAI 兼容服务
+ */
+export type TranscriptionProvider = 'openai' | 'groq' | 'custom'
+
+/**
+ * Provider 预设模型
+ */
+export interface ProviderModelPreset {
+  value: string
+  label: string
+  description?: string
+}
+
+/**
+ * Provider 配置元数据
+ */
+export interface ProviderMeta {
+  id: TranscriptionProvider
+  name: string
+  defaultBaseUrl: string
+  models: ProviderModelPreset[]
+  requiresBaseUrl: boolean
+}
+
+/**
+ * Provider 配置预设
+ */
+export const TRANSCRIPTION_PROVIDERS: ProviderMeta[] = [
+  {
+    id: 'openai',
+    name: 'OpenAI',
+    defaultBaseUrl: 'https://api.openai.com/v1',
+    requiresBaseUrl: false,
+    models: [
+      { value: 'whisper-1', label: 'whisper-1', description: '经典 Whisper，稳定可靠' },
+      { value: 'gpt-4o-transcribe', label: 'gpt-4o-transcribe', description: '更高准确率' },
+      { value: 'gpt-4o-mini-transcribe', label: 'gpt-4o-mini-transcribe', description: '更快更便宜' },
+    ],
+  },
+  {
+    id: 'groq',
+    name: 'Groq',
+    defaultBaseUrl: 'https://api.groq.com/openai/v1',
+    requiresBaseUrl: false,
+    models: [
+      { value: 'whisper-large-v3-turbo', label: 'whisper-large-v3-turbo', description: '高速，推荐' },
+      { value: 'whisper-large-v3', label: 'whisper-large-v3', description: '更高准确率' },
+      { value: 'distil-whisper-large-v3-en', label: 'distil-whisper-large-v3-en', description: '英文专用' },
+    ],
+  },
+  {
+    id: 'custom',
+    name: '自定义',
+    defaultBaseUrl: '',
+    requiresBaseUrl: true,
+    models: [],
+  },
+]
+
+/**
+ * 在线转录配置
+ */
+export interface OnlineTranscriptionConfig {
+  provider: TranscriptionProvider
+  apiKey: string
+  modelId: string
+  baseUrl?: string
+  language?: string
+  responseFormat?: 'text' | 'json'
+  temperature?: number
+  timeoutMs?: number
+}
+
+export interface TranscriptionSettings {
+  mode: TranscriptionMode
+  online: OnlineTranscriptionConfig
+}

--- a/src/components/AppSettings.tsx
+++ b/src/components/AppSettings.tsx
@@ -77,10 +77,6 @@ export const AppSettings = memo<AppSettingsProps>(({
     await onUpdateAllowBetaUpdates(true)
   }, [onUpdateAllowBetaUpdates])
 
-  const handleCacheTTLChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
-    onUpdateCacheTTL(Number(e.target.value))
-  }, [onUpdateCacheTTL])
-
   const Toggle = ({ enabled, onToggle, label }: { enabled: boolean; onToggle: () => void; label: string }) => (
     <div className="flex items-center justify-between py-1.5">
       <span className="text-xs text-gray-600">{label}</span>
@@ -145,19 +141,23 @@ export const AppSettings = memo<AppSettingsProps>(({
         )}
 
         <div className="divide-y divide-gray-50">
-          <div className="flex items-center justify-between py-1.5">
+          <div className="py-1.5">
             <span className="text-xs text-gray-600">模型缓存时间</span>
-            <select
-              value={cacheTTLMinutes}
-              onChange={handleCacheTTLChange}
-              className="text-xs bg-gray-50 border border-gray-200 rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-[hsl(var(--primary))]"
-            >
+            <div className="flex flex-wrap gap-1.5 mt-1.5">
               {CACHE_TTL_OPTIONS.map((opt) => (
-                <option key={opt.value} value={opt.value}>
+                <button
+                  key={opt.value}
+                  onClick={() => onUpdateCacheTTL(opt.value)}
+                  className={`px-2.5 py-1 text-xs rounded-full border transition-all ${
+                    cacheTTLMinutes === opt.value
+                      ? 'bg-orange-50 border-orange-300 text-orange-700 font-medium'
+                      : 'bg-gray-50 border-gray-200 text-gray-600 hover:border-gray-300'
+                  }`}
+                >
                   {opt.label}
-                </option>
+                </button>
               ))}
-            </select>
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/ModelSettings.tsx
+++ b/src/components/ModelSettings.tsx
@@ -1,0 +1,523 @@
+/**
+ * 转录模型设置组件
+ * Provider 卡片列表 → 选中后展开配置
+ */
+
+import { useCallback, useEffect, useState, useMemo } from 'react'
+import type { OnlineTranscriptionConfig, TranscriptionSettings, TranscriptionProvider } from '../../shared/app-state'
+import { TRANSCRIPTION_PROVIDERS } from '../../shared/app-state'
+
+interface ModelSettingsProps {
+  config: TranscriptionSettings | null
+  onConfigChange: (config: TranscriptionSettings) => Promise<{ success: boolean; error?: string }>
+}
+
+const DEFAULT_ONLINE_CONFIG: OnlineTranscriptionConfig = {
+  provider: 'openai',
+  apiKey: '',
+  modelId: 'whisper-1',
+  responseFormat: 'json',
+  temperature: 0,
+  timeoutMs: 120000,
+}
+
+const DEFAULT_SETTINGS: TranscriptionSettings = {
+  mode: 'offline',
+  online: DEFAULT_ONLINE_CONFIG,
+}
+
+const LANGUAGE_PRESETS = [
+  { value: '', label: '自动' },
+  { value: 'zh', label: '中文' },
+  { value: 'en', label: 'EN' },
+  { value: 'ja', label: '日本語' },
+] as const
+
+export const ModelSettings = ({ config, onConfigChange }: ModelSettingsProps) => {
+  const [localConfig, setLocalConfig] = useState<TranscriptionSettings>(() => config || DEFAULT_SETTINGS)
+  const [showApiKey, setShowApiKey] = useState(false)
+  const [showAdvanced, setShowAdvanced] = useState(false)
+  const [expandedProvider, setExpandedProvider] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [testing, setTesting] = useState(false)
+  const [testResult, setTestResult] = useState<{ success: boolean; message: string } | null>(null)
+  const [customModelInput, setCustomModelInput] = useState('')
+  const [showCustomModel, setShowCustomModel] = useState(false)
+
+  const currentProvider = useMemo(() => {
+    return TRANSCRIPTION_PROVIDERS.find(p => p.id === localConfig.online.provider) || TRANSCRIPTION_PROVIDERS[0]
+  }, [localConfig.online.provider])
+
+  const isCustomModel = useMemo(() => {
+    if (currentProvider.id === 'custom') return true
+    return !currentProvider.models.some(m => m.value === localConfig.online.modelId)
+  }, [currentProvider, localConfig.online.modelId])
+
+  useEffect(() => {
+    if (config) {
+      setLocalConfig(config)
+      const provider = TRANSCRIPTION_PROVIDERS.find(p => p.id === config.online.provider)
+      if (config.online.modelId && provider && !provider.models.some(m => m.value === config.online.modelId)) {
+        setCustomModelInput(config.online.modelId)
+        setShowCustomModel(true)
+      }
+    }
+  }, [config])
+
+  const commitChange = useCallback(async (next: TranscriptionSettings, fallback?: TranscriptionSettings) => {
+    const normalized = next.mode === 'online'
+      ? { ...next, online: { ...next.online, responseFormat: 'json' } }
+      : next
+    setLocalConfig(normalized)
+    setSaving(true)
+    const result = await onConfigChange(normalized)
+    setSaving(false)
+    if (!result.success && fallback) {
+      setLocalConfig(fallback)
+    }
+  }, [onConfigChange])
+
+  const handleModeChange = useCallback(async (mode: 'offline' | 'online') => {
+    const previous = localConfig
+    const next = { ...localConfig, mode }
+    setTestResult(null)
+    await commitChange(next, previous)
+  }, [localConfig, commitChange])
+
+  const updateOnlineField = useCallback((patch: Partial<OnlineTranscriptionConfig>) => {
+    setLocalConfig(prev => ({
+      ...prev,
+      online: { ...prev.online, ...patch },
+    }))
+    setTestResult(null)
+  }, [])
+
+  const handleProviderChange = useCallback(async (providerId: TranscriptionProvider) => {
+    const providerMeta = TRANSCRIPTION_PROVIDERS.find(p => p.id === providerId)
+    if (!providerMeta) return
+
+    const defaultModel = providerMeta.models[0]?.value || ''
+    setShowCustomModel(providerId === 'custom')
+    setCustomModelInput('')
+    const next: TranscriptionSettings = {
+      ...localConfig,
+      online: {
+        ...localConfig.online,
+        provider: providerId,
+        modelId: defaultModel,
+        baseUrl: undefined,
+      },
+    }
+    setTestResult(null)
+    await commitChange(next)
+  }, [localConfig, commitChange])
+
+  const handleModelChange = useCallback(async (modelId: string) => {
+    setShowCustomModel(false)
+    const next = { ...localConfig, online: { ...localConfig.online, modelId } }
+    await commitChange(next)
+  }, [localConfig, commitChange])
+
+  const handleCustomModelToggle = useCallback(() => {
+    setShowCustomModel(true)
+    setCustomModelInput('')
+    updateOnlineField({ modelId: '' })
+  }, [updateOnlineField])
+
+  const handleOnlineBlur = useCallback(async () => {
+    if (!config) return
+    if (JSON.stringify(localConfig) === JSON.stringify(config)) return
+    await commitChange(localConfig)
+  }, [config, localConfig, commitChange])
+
+  const handleCustomModelBlur = useCallback(async () => {
+    if (customModelInput) {
+      updateOnlineField({ modelId: customModelInput })
+    }
+    await handleOnlineBlur()
+  }, [customModelInput, updateOnlineField, handleOnlineBlur])
+
+  const handleLanguageChange = useCallback(async (lang: string) => {
+    const next = { ...localConfig, online: { ...localConfig.online, language: lang || undefined } }
+    await commitChange(next)
+  }, [localConfig, commitChange])
+
+  const handleTestConnection = useCallback(async () => {
+    if (!localConfig.online.apiKey || !localConfig.online.modelId) {
+      setTestResult({ success: false, message: '请先填写 API Key 和模型' })
+      return
+    }
+    if (currentProvider.requiresBaseUrl && !localConfig.online.baseUrl) {
+      setTestResult({ success: false, message: '请填写 Base URL' })
+      return
+    }
+
+    setTesting(true)
+    setTestResult(null)
+
+    try {
+      const result = await window.speech.testTranscription()
+      if (result.success) {
+        setTestResult({
+          success: true,
+          message: `成功: "${result.text?.slice(0, 20)}${(result.text?.length ?? 0) > 20 ? '...' : ''}"`,
+        })
+      } else {
+        setTestResult({ success: false, message: result.error || '测试失败' })
+      }
+    } catch (err) {
+      setTestResult({ success: false, message: err instanceof Error ? err.message : '测试失败' })
+    } finally {
+      setTesting(false)
+    }
+  }, [localConfig.online, currentProvider.requiresBaseUrl])
+
+  const isConfigValid = localConfig.online.apiKey && localConfig.online.modelId
+    && (currentProvider.id !== 'custom' || localConfig.online.baseUrl)
+
+  const PillButton = ({ active, onClick, disabled, children, title }: {
+    active: boolean
+    onClick: () => void
+    disabled?: boolean
+    children: React.ReactNode
+    title?: string
+  }) => (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      title={title}
+      className={`px-2.5 py-1 text-xs rounded-full border transition-all whitespace-nowrap ${
+        active
+          ? 'bg-orange-50 border-orange-300 text-orange-700 font-medium'
+          : 'bg-gray-50 border-gray-200 text-gray-600 hover:border-gray-300'
+      } ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+    >
+      {children}
+    </button>
+  )
+
+  return (
+    <div className="space-y-4">
+      <div className="bg-white rounded-xl border border-gray-100 shadow-sm p-3 space-y-3">
+        {/* 转录模式 */}
+        <div>
+          <span className="text-xs font-medium text-gray-600">转录模式</span>
+          <div className="flex gap-2 mt-1.5">
+            <button
+              onClick={() => handleModeChange('offline')}
+              disabled={saving}
+              className={`flex-1 px-2 py-1.5 text-xs rounded-lg border transition-all ${
+                localConfig.mode === 'offline'
+                  ? 'bg-orange-50 border-orange-300 text-orange-700 font-medium'
+                  : 'bg-gray-50 border-gray-200 text-gray-600 hover:border-gray-300'
+              } ${saving ? 'opacity-50' : ''}`}
+            >
+              离线（SenseVoice）
+            </button>
+            <button
+              onClick={() => handleModeChange('online')}
+              disabled={saving}
+              className={`flex-1 px-2 py-1.5 text-xs rounded-lg border transition-all ${
+                localConfig.mode === 'online'
+                  ? 'bg-orange-50 border-orange-300 text-orange-700 font-medium'
+                  : 'bg-gray-50 border-gray-200 text-gray-600 hover:border-gray-300'
+              } ${saving ? 'opacity-50' : ''}`}
+            >
+              在线（云端 API）
+            </button>
+          </div>
+        </div>
+
+        {localConfig.mode === 'offline' && (
+          <div className="px-3 py-2 bg-gray-50 border border-gray-100 rounded-lg">
+            <p className="text-xs text-gray-600">使用本地 SenseVoice 模型，数据不离开设备。</p>
+          </div>
+        )}
+
+        {localConfig.mode === 'online' && (
+          <div className="space-y-3">
+            <div className="flex items-center gap-2 px-2.5 py-1.5 bg-amber-50 border border-amber-200 rounded-lg">
+              <span className="text-amber-600 text-xs">⚠️</span>
+              <span className="text-[11px] text-amber-700">在线模式会上传音频，可能产生费用</span>
+            </div>
+
+            {/* Provider 卡片列表 */}
+            <div className="space-y-2">
+              {TRANSCRIPTION_PROVIDERS.map((provider) => {
+                const isActive = localConfig.online.provider === provider.id
+                const isExpanded = isActive && expandedProvider === provider.id
+                const selectedModel = isActive
+                  ? provider.models.find(m => m.value === localConfig.online.modelId)?.label || localConfig.online.modelId
+                  : null
+                return (
+                  <div
+                    key={provider.id}
+                    className={`rounded-lg border transition-all ${
+                      isActive
+                        ? 'border-orange-300 bg-orange-50/30'
+                        : 'border-gray-200 bg-gray-50 hover:border-gray-300'
+                    }`}
+                  >
+                    {/* Provider 头部 */}
+                    <button
+                      onClick={() => {
+                        if (isActive) {
+                          setExpandedProvider(isExpanded ? null : provider.id)
+                        } else {
+                          handleProviderChange(provider.id)
+                          setExpandedProvider(provider.id)
+                        }
+                      }}
+                      disabled={saving}
+                      className={`w-full px-3 py-2 flex items-center justify-between ${saving ? 'opacity-50' : ''}`}
+                    >
+                      <div className="flex items-center gap-2">
+                        <span className={`w-2 h-2 rounded-full ${isActive ? 'bg-orange-500' : 'bg-gray-300'}`} />
+                        <span className={`text-xs font-medium ${isActive ? 'text-orange-700' : 'text-gray-600'}`}>
+                          {provider.name}
+                        </span>
+
+                        {isActive && selectedModel && (
+                          <span className="px-1.5 py-0.5 text-[10px] bg-orange-100 text-orange-600 rounded truncate max-w-[120px]">
+                            {selectedModel}
+                          </span>
+                        )}
+                      </div>
+                      <svg
+                        className={`w-4 h-4 text-gray-400 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                      >
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                      </svg>
+                    </button>
+
+                    {/* Provider 配置（展开时显示） */}
+                    {isExpanded && (
+                      <div className="px-3 pb-3 space-y-3 border-t border-orange-200/50">
+                        {/* 模型选择 */}
+                        {provider.models.length > 0 && (
+                          <div className="pt-3">
+                            <span className="text-xs font-medium text-gray-600">模型</span>
+                            <div className="flex flex-wrap gap-1.5 mt-1.5">
+                              {provider.models.map((model) => (
+                                <PillButton
+                                  key={model.value}
+                                  active={localConfig.online.modelId === model.value && !showCustomModel}
+                                  onClick={() => handleModelChange(model.value)}
+                                  disabled={saving}
+                                  title={model.description}
+                                >
+                                  {model.label}
+                                </PillButton>
+                              ))}
+                              <PillButton
+                                active={showCustomModel || isCustomModel}
+                                onClick={handleCustomModelToggle}
+                                disabled={saving}
+                              >
+                                自定义
+                              </PillButton>
+                            </div>
+                          </div>
+                        )}
+
+                        {/* 自定义模型输入 */}
+                        {(showCustomModel || isCustomModel || provider.id === 'custom') && (
+                          <div>
+                            <span className="text-xs font-medium text-gray-600">模型 ID</span>
+                            <input
+                              type="text"
+                              value={showCustomModel ? customModelInput : localConfig.online.modelId}
+                              onChange={(e) => {
+                                if (showCustomModel) {
+                                  setCustomModelInput(e.target.value)
+                                } else {
+                                  updateOnlineField({ modelId: e.target.value })
+                                }
+                              }}
+                              onBlur={showCustomModel ? handleCustomModelBlur : handleOnlineBlur}
+                              placeholder="输入模型 ID"
+                              className="w-full mt-1.5 px-3 py-2 text-xs border border-gray-200 rounded-lg bg-white focus:outline-none focus:border-orange-300 focus:ring-1 focus:ring-orange-100"
+                            />
+                          </div>
+                        )}
+
+                        {/* API Key */}
+                        <div>
+                          <span className="text-xs font-medium text-gray-600">API Key</span>
+                          <div className="relative mt-1.5">
+                            <input
+                              type={showApiKey ? 'text' : 'password'}
+                              value={localConfig.online.apiKey}
+                              onChange={(e) => updateOnlineField({ apiKey: e.target.value })}
+                              onBlur={handleOnlineBlur}
+                              placeholder={provider.id === 'groq' ? 'gsk_...' : 'sk-...'}
+                              className="w-full px-3 py-2 pr-14 text-xs border border-gray-200 rounded-lg bg-white focus:outline-none focus:border-orange-300 focus:ring-1 focus:ring-orange-100"
+                            />
+                            <button
+                              type="button"
+                              onClick={() => setShowApiKey(!showApiKey)}
+                              className="absolute right-2 top-1/2 -translate-y-1/2 text-[11px] text-gray-400 hover:text-gray-600"
+                            >
+                              {showApiKey ? '隐藏' : '显示'}
+                            </button>
+                          </div>
+                        </div>
+
+                        {/* Base URL（自定义 Provider 必填） */}
+                        {provider.requiresBaseUrl && (
+                          <div>
+                            <span className="text-xs font-medium text-gray-600">
+                              Base URL <span className="text-rose-500">*</span>
+                            </span>
+                            <input
+                              type="text"
+                              value={localConfig.online.baseUrl || ''}
+                              onChange={(e) => updateOnlineField({ baseUrl: e.target.value || undefined })}
+                              onBlur={handleOnlineBlur}
+                              placeholder="https://your-api.example.com/v1"
+                              className="w-full mt-1.5 px-3 py-2 text-xs border border-gray-200 rounded-lg bg-white focus:outline-none focus:border-orange-300 focus:ring-1 focus:ring-orange-100"
+                            />
+                          </div>
+                        )}
+
+                        {/* 语言选择 */}
+                        <div>
+                          <span className="text-xs font-medium text-gray-600">语言</span>
+                          <div className="flex flex-wrap gap-1.5 mt-1.5">
+                            {LANGUAGE_PRESETS.map((lang) => (
+                              <PillButton
+                                key={lang.value}
+                                active={(localConfig.online.language || '') === lang.value}
+                                onClick={() => handleLanguageChange(lang.value)}
+                                disabled={saving}
+                              >
+                                {lang.label}
+                              </PillButton>
+                            ))}
+                          </div>
+                        </div>
+
+                        {/* 高级设置 */}
+                        <div>
+                          <button
+                            onClick={() => setShowAdvanced(!showAdvanced)}
+                            className="text-xs text-gray-500 hover:text-gray-700 flex items-center gap-1"
+                          >
+                            <span>{showAdvanced ? '收起' : '高级设置'}</span>
+                            <svg
+                              className={`w-3 h-3 transition-transform ${showAdvanced ? 'rotate-180' : ''}`}
+                              fill="none"
+                              viewBox="0 0 24 24"
+                              stroke="currentColor"
+                            >
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                            </svg>
+                          </button>
+
+                          {showAdvanced && (
+                            <div className="mt-2 space-y-3">
+                              {!provider.requiresBaseUrl && (
+                                <div>
+                                  <span className="text-xs font-medium text-gray-600">Base URL（可选）</span>
+                                  <input
+                                    type="text"
+                                    value={localConfig.online.baseUrl || ''}
+                                    onChange={(e) => updateOnlineField({ baseUrl: e.target.value || undefined })}
+                                    onBlur={handleOnlineBlur}
+                                    placeholder={provider.defaultBaseUrl}
+                                    className="w-full mt-1.5 px-3 py-2 text-xs border border-gray-200 rounded-lg bg-white focus:outline-none focus:border-orange-300 focus:ring-1 focus:ring-orange-100"
+                                  />
+                                  <p className="text-[11px] text-gray-400 mt-1">留空使用官方地址</p>
+                                </div>
+                              )}
+
+                              <div className="grid grid-cols-2 gap-3">
+                                <div>
+                                  <span className="text-xs font-medium text-gray-600">温度</span>
+                                  <input
+                                    type="number"
+                                    step="0.1"
+                                    min="0"
+                                    max="1"
+                                    value={localConfig.online.temperature ?? ''}
+                                    onChange={(e) => {
+                                      const v = e.target.value
+                                      updateOnlineField({ temperature: v ? Number(v) : undefined })
+                                    }}
+                                    onBlur={handleOnlineBlur}
+                                    placeholder="0"
+                                    className="w-full mt-1.5 px-3 py-2 text-xs border border-gray-200 rounded-lg bg-white focus:outline-none focus:border-orange-300 focus:ring-1 focus:ring-orange-100"
+                                  />
+                                </div>
+                                <div>
+                                  <span className="text-xs font-medium text-gray-600">超时（秒）</span>
+                                  <input
+                                    type="number"
+                                    step="10"
+                                    min="10"
+                                    value={localConfig.online.timeoutMs ? Math.round(localConfig.online.timeoutMs / 1000) : ''}
+                                    onChange={(e) => {
+                                      const v = e.target.value
+                                      updateOnlineField({ timeoutMs: v ? Number(v) * 1000 : undefined })
+                                    }}
+                                    onBlur={handleOnlineBlur}
+                                    placeholder="120"
+                                    className="w-full mt-1.5 px-3 py-2 text-xs border border-gray-200 rounded-lg bg-white focus:outline-none focus:border-orange-300 focus:ring-1 focus:ring-orange-100"
+                                  />
+                                </div>
+                              </div>
+                            </div>
+                          )}
+                        </div>
+
+                        {/* 配置验证提示 */}
+                        {!isConfigValid && (
+                          <div className="text-xs text-rose-600">
+                            {!localConfig.online.apiKey && '请填写 API Key'}
+                            {!localConfig.online.apiKey && !localConfig.online.modelId && ' · '}
+                            {!localConfig.online.modelId && '请填写模型'}
+                            {provider.requiresBaseUrl && !localConfig.online.baseUrl && ' · 请填写 Base URL'}
+                          </div>
+                        )}
+
+                        {/* 测试连接 */}
+                        <div className="pt-2 border-t border-orange-200/50">
+                          <button
+                            onClick={handleTestConnection}
+                            disabled={testing || !isConfigValid}
+                            className={`w-full px-3 py-2 text-xs rounded-lg border transition-all ${
+                              testing
+                                ? 'bg-gray-100 border-gray-200 text-gray-400 cursor-wait'
+                                : isConfigValid
+                                  ? 'bg-blue-50 border-blue-200 text-blue-700 hover:bg-blue-100'
+                                  : 'bg-gray-50 border-gray-200 text-gray-400 cursor-not-allowed'
+                            }`}
+                          >
+                            {testing ? '测试中...' : '🔗 测试连接'}
+                          </button>
+
+                          {testResult && (
+                            <div className={`mt-2 px-3 py-2 rounded-lg text-xs ${
+                              testResult.success
+                                ? 'bg-green-50 border border-green-200 text-green-700'
+                                : 'bg-rose-50 border border-rose-200 text-rose-700'
+                            }`}>
+                              {testResult.success ? '✅ ' : '❌ '}{testResult.message}
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Add support for online transcription APIs as an alternative to the existing local SenseVoice model. Supports multiple providers with OpenAI-compatible API.

## Supported Providers

- **OpenAI** - `whisper-1`, `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`
- **Groq** - `whisper-large-v3`, `whisper-large-v3-turbo`, `distil-whisper-large-v3-en`
- **Custom** - Any OpenAI-compatible endpoint

## Changes

- **Online Transcriber** (`electron/transcriber/openai-transcriber.ts`): Generic implementation supporting all OpenAI-compatible APIs
- **Model Settings UI** (`src/components/ModelSettings.tsx`): Settings panel for switching modes, selecting providers, and configuring API keys
- **App Controller Updates**: Handle transcriber mode switching at runtime
- **Config Persistence**: Store transcriber settings (mode, provider, API key, model) in user config
- **Type Definitions**: Add `TranscriptionMode`, `TranscriptionProvider`, `OnlineTranscriptionConfig` types

## Features

- Switch between `offline` (SenseVoice) and `online` transcription
- Provider selection with preset models
- Custom base URL support for self-hosted services
- Secure API key storage in user config
- Configurable timeout, language, and response format
- Real-time transcriber switching without app restart

## Testing

- [x] Local SenseVoice transcription still works
- [x] OpenAI Whisper transcription
- [x] Groq transcription
- [x] Mode/provider switching in settings UI
- [x] API key persistence across app restarts