### PR TITLE
refactor: use function calling for AI correction engine

### DIFF
--- a/electron/config/index.ts
+++ b/electron/config/index.ts
@@ -189,7 +189,7 @@ const DEFAULT_POLISH_CONFIG: PolishConfig = {
   provider: 'openai',
   apiKey: '',
   modelId: 'gpt-4o-mini',
-  systemPrompt: '你是一个语音转文字的润色助手。用户输入的是语音识别后的原始文本，可能包含口语化表达、重复、填充词等。请将其润色为流畅、简洁的书面文本，保持原意不变。只输出润色后的文本，不要添加任何解释或额外内容。',
+  systemPrompt: '',
   timeoutMs: 30000,
 }
 

--- a/electron/core/app-controller.ts
+++ b/electron/core/app-controller.ts
@@ -578,9 +578,13 @@ export class AppController {
         if (polishResult.success && polishResult.text) {
           finalText = polishResult.text
           polished = true
-          logger.info('AI 润色完成', { sessionId, durationMs: polishResult.durationMs })
+          if (polishResult.filtered) {
+            logger.warn('AI 纠正内容被过滤', { sessionId, reason: polishResult.filterReason })
+          } else {
+            logger.info('AI 纠正完成', { sessionId, durationMs: polishResult.durationMs })
+          }
         } else {
-          logger.warn('AI 润色失败，回退到原始文本', { error: polishResult.error })
+          logger.warn('AI 纠正失败，回退到原始文本', { error: polishResult.error })
         }
       }
 

--- a/electron/services/polish-engine.ts
+++ b/electron/services/polish-engine.ts
@@ -1,8 +1,9 @@
 /**
- * SpeechTide AI 润色引擎
+ * SpeechTide AI 纠正引擎
  *
- * 使用 OpenAI-compatible API 对转写文本进行润色
+ * 使用 OpenAI-compatible API 对语音转写文本进行纠正
  * 支持 OpenAI、DeepSeek 等兼容 API
+ * 采用 Function Calling 强制结构化输出
  */
 
 import type { PolishConfig } from '../../shared/app-state'
@@ -15,7 +16,50 @@ export interface PolishResult {
   text?: string
   error?: string
   durationMs?: number
+  filtered?: boolean
+  filterReason?: string
 }
+
+const CORRECTION_TOOL = {
+  type: 'function' as const,
+  function: {
+    name: 'return_correction',
+    description: 'Return the correction result for the transcription as structured data.',
+    parameters: {
+      type: 'object',
+      properties: {
+        status: {
+          type: 'string',
+          enum: ['ok', 'filtered'],
+          description: 'Use ok when the correction succeeds. Use filtered when safety policies prevent modification and the original text must be kept.',
+        },
+        text: {
+          type: 'string',
+          description: 'The corrected transcription text, or the original text when status is filtered or no change is required.',
+        },
+        reason: {
+          type: 'string',
+          description: 'Optional explanation when status is filtered. Leave empty otherwise.',
+        },
+      },
+      required: ['status', 'text'],
+    },
+  },
+}
+
+const DEFAULT_CORRECTION_PROMPT = `你是一个语音转写文本纠正助手。
+
+你的任务：
+- 修正语音识别文本中的识别错误、同音字错误、错别字和标点问题
+- 保持原意，不增删信息
+- 当识别结果中出现与用户词典中词汇发音相似、拼写接近或语义相关的词时，将其替换为词典中的标准形式
+- 不要更改词典中词汇的拼写、大小写或符号
+
+输出：
+调用一次名为 return_correction 的函数，参数：
+status: "ok" 或 "filtered"
+text: 纠正后的文本或原文
+reason: 可选（若触发内容安全限制，说明原因）`
 
 /**
  * 根据 provider 获取 base URL
@@ -60,24 +104,26 @@ export class PolishEngine {
   }
 
   /**
-   * 执行润色
+   * 执行纠正（使用 Function Calling）
    */
   async polish(rawText: string): Promise<PolishResult> {
     if (!this.isConfigValid()) {
-      return { success: false, error: '润色配置无效或未启用' }
+      return { success: false, error: '纠正配置无效或未启用' }
     }
 
     const startTime = Date.now()
     const baseUrl = getBaseUrl(this.config)
     const url = `${baseUrl}/chat/completions`
 
-    logger.info('开始润色', { provider: this.config.provider, modelId: this.config.modelId, textLength: rawText.length })
+    logger.info('开始纠正', { provider: this.config.provider, modelId: this.config.modelId, textLength: rawText.length })
 
     try {
       const controller = new AbortController()
       const timeoutId = setTimeout(() => controller.abort(), this.config.timeoutMs)
 
       try {
+        const systemPrompt = this.config.systemPrompt || DEFAULT_CORRECTION_PROMPT
+
         const response = await fetch(url, {
           method: 'POST',
           headers: {
@@ -87,11 +133,16 @@ export class PolishEngine {
           body: JSON.stringify({
             model: this.config.modelId,
             messages: [
-              { role: 'system', content: this.config.systemPrompt },
+              { role: 'system', content: systemPrompt },
               { role: 'user', content: rawText },
             ],
             temperature: 0.3,
-            max_tokens: 2048,
+            max_tokens: 4096,
+            tools: [CORRECTION_TOOL],
+            tool_choice: {
+              type: 'function',
+              function: { name: 'return_correction' },
+            },
           }),
           signal: controller.signal,
         })
@@ -102,26 +153,57 @@ export class PolishEngine {
           return { success: false, error: `API 请求失败: HTTP ${response.status}` }
         }
 
-        const data = await response.json() as {
-          choices?: Array<{ message?: { content?: string } }>
+        interface ToolCall {
+          function?: { name?: string; arguments?: string }
+        }
+        interface ApiResponse {
+          choices?: Array<{ message?: { tool_calls?: ToolCall[] } }>
           error?: { message?: string }
         }
+
+        const data = await response.json() as ApiResponse
 
         if (data.error) {
           logger.error(new Error(`API 返回错误: ${data.error.message}`), { error: data.error })
           return { success: false, error: data.error.message || 'API 返回错误' }
         }
 
-        const polishedText = data.choices?.[0]?.message?.content?.trim()
-        if (!polishedText) {
-          logger.error(new Error('API 返回空内容'), { data })
-          return { success: false, error: 'API 返回空内容' }
+        const toolCall = data.choices?.[0]?.message?.tool_calls?.[0]
+        if (!toolCall?.function?.arguments) {
+          logger.error(new Error('API 未返回 function call'), { data })
+          return { success: false, error: 'API 未返回有效的纠正结果' }
+        }
+
+        interface CorrectionResult {
+          status: 'ok' | 'filtered'
+          text: string
+          reason?: string
+        }
+
+        let result: CorrectionResult
+        try {
+          result = JSON.parse(toolCall.function.arguments) as CorrectionResult
+        } catch {
+          logger.error(new Error('解析 function call 参数失败'), { arguments: toolCall.function.arguments })
+          return { success: false, error: '解析纠正结果失败' }
         }
 
         const durationMs = Date.now() - startTime
-        logger.info('润色完成', { durationMs, inputLength: rawText.length, outputLength: polishedText.length })
 
-        return { success: true, text: polishedText, durationMs }
+        if (result.status === 'filtered') {
+          logger.warn('内容被过滤', { reason: result.reason })
+          return {
+            success: true,
+            text: result.text,
+            durationMs,
+            filtered: true,
+            filterReason: result.reason,
+          }
+        }
+
+        logger.info('纠正完成', { durationMs, inputLength: rawText.length, outputLength: result.text.length })
+
+        return { success: true, text: result.text, durationMs }
       } finally {
         clearTimeout(timeoutId)
       }
@@ -129,8 +211,8 @@ export class PolishEngine {
       const durationMs = Date.now() - startTime
       if (error instanceof Error) {
         if (error.name === 'AbortError') {
-          logger.error(new Error('润色超时'), { timeoutMs: this.config.timeoutMs })
-          return { success: false, error: `润色超时（${this.config.timeoutMs / 1000}秒）`, durationMs }
+          logger.error(new Error('纠正超时'), { timeoutMs: this.config.timeoutMs })
+          return { success: false, error: `纠正超时（${this.config.timeoutMs / 1000}秒）`, durationMs }
         }
         logger.error(error, { context: 'polish' })
         return { success: false, error: error.message, durationMs }


### PR DESCRIPTION
## Overview

Upgrade AI correction engine from text-based output to Function Calling mode for improved structured and reliable output.

## Changes

### polish-engine.ts
- Add `CORRECTION_TOOL` definition with `return_correction` function
- Add `DEFAULT_CORRECTION_PROMPT` for correction-focused instructions
- Use `tool_choice` to force structured function calling
- Parse `tool_calls` response instead of `message.content`
- Add `filtered` and `filterReason` fields to `PolishResult`

### config/index.ts
- Set default `systemPrompt` to empty (engine uses built-in default)

## Benefits

1. **Clear Role**: Changed from "polishing assistant" to "correction assistant" to avoid over-editing
2. **Structured Output**: Function Calling enforces JSON response, preventing LLM from free-form output
3. **Safety Filtering**: Support `status: filtered` mechanism for sensitive content handling

## Testing

- [ ] Offline transcription + AI correction works
- [ ] Online transcription + AI correction works
- [ ] Correction timeout handled correctly
- [ ] API errors displayed properly